### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/charts/pumperly/.helmignore
+++ b/charts/pumperly/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/pumperly/Chart.yaml
+++ b/charts/pumperly/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: pumperly
 description: A Helm chart for Pumperly - Open-source fuel and EV route planner
 type: application
+kubeVersion: ">=1.21.0-0"
 version: 0.1.0
 appVersion: "1.2.0"
 keywords:

--- a/charts/pumperly/Chart.yaml
+++ b/charts/pumperly/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: pumperly
+description: A Helm chart for Pumperly - Open-source fuel and EV route planner
+type: application
+version: 0.1.0
+appVersion: "1.2.0"
+keywords:
+  - pumperly
+  - fuel
+  - ev
+  - route-planner
+  - maps
+  - postgis
+  - self-hosted
+home: https://pumperly.com
+sources:
+  - https://github.com/GeiserX/Pumperly
+maintainers:
+  - name: Sergio Fernandez
+    email: acsdesk@protonmail.com
+annotations:
+  category: Maps

--- a/charts/pumperly/README.md
+++ b/charts/pumperly/README.md
@@ -56,6 +56,7 @@ helm upgrade --install pumperly ./charts/pumperly -f my-values.yaml
   - optional API key entries: `TANKERKOENIG_API_KEY`, `PUMPERLY_OCM_API_KEY`, `FUELPRICES_DK_API_KEY`
 - `externalDatabase.*`: required when `postgis.enabled=false` and you are not supplying a full `externalDatabase.url`
 - `waitForDatabase.enabled`: if you keep it enabled with an external DB, also set `externalDatabase.host` so the init container has something to probe
+- `waitForDatabase.timeoutSeconds`: fail startup if the database never becomes reachable instead of waiting forever
 - `deploymentStrategy.type`: switch back to `RollingUpdate` only if you are comfortable with overlapping scraper pods during upgrades
 - `postgis.enabled`: disable bundled PostGIS for managed PostgreSQL/PostGIS
 - `databaseInit.enabled`: run `npx prisma db push` before the app starts

--- a/charts/pumperly/README.md
+++ b/charts/pumperly/README.md
@@ -13,8 +13,10 @@ This chart deploys the Pumperly web application plus optional bundled PostGIS, V
 ## Important Notes
 
 - Keep `replicaCount: 1` unless you intentionally disable or externalize scraping. Pumperly runs scrapers inside the web process.
+- The chart defaults the web Deployment to `Recreate` so upgrades do not overlap two scraper pods.
 - Photon is not plug-and-play. If `photon.enabled=true`, you must provide a working image plus `photon.command`/`photon.args`.
 - For external infrastructure, disable `postgis.enabled` and use `externalDatabase` plus `externalServices.valhallaUrl` / `externalServices.photonUrl`.
+- If you rely on chart-managed secrets, `helm upgrade` will now roll the web pod when the generated Secret changes.
 
 ## Minimal Example
 
@@ -52,6 +54,9 @@ helm upgrade --install pumperly ./charts/pumperly -f my-values.yaml
   - always provide `DATABASE_URL`
   - if `postgis.enabled=true`, also provide `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`
   - optional API key entries: `TANKERKOENIG_API_KEY`, `PUMPERLY_OCM_API_KEY`, `FUELPRICES_DK_API_KEY`
+- `externalDatabase.*`: required when `postgis.enabled=false` and you are not supplying a full `externalDatabase.url`
+- `waitForDatabase.enabled`: if you keep it enabled with an external DB, also set `externalDatabase.host` so the init container has something to probe
+- `deploymentStrategy.type`: switch back to `RollingUpdate` only if you are comfortable with overlapping scraper pods during upgrades
 - `postgis.enabled`: disable bundled PostGIS for managed PostgreSQL/PostGIS
 - `databaseInit.enabled`: run `npx prisma db push` before the app starts
 - `externalServices.valhallaUrl`: use an external Valhalla instance

--- a/charts/pumperly/README.md
+++ b/charts/pumperly/README.md
@@ -1,0 +1,59 @@
+# Pumperly Helm Chart
+
+This chart deploys the Pumperly web application plus optional bundled PostGIS, Valhalla, and Photon components.
+
+## What This Chart Handles
+
+- Pumperly web Deployment
+- Optional bundled PostGIS StatefulSet
+- Optional Valhalla routing Deployment
+- Optional Photon Deployment when you provide a real image and startup command
+- Automatic `npx prisma db push` init step for the primary database
+
+## Important Notes
+
+- Keep `replicaCount: 1` unless you intentionally disable or externalize scraping. Pumperly runs scrapers inside the web process.
+- Photon is not plug-and-play. If `photon.enabled=true`, you must provide a working image plus `photon.command`/`photon.args`.
+- For external infrastructure, disable `postgis.enabled` and use `externalDatabase` plus `externalServices.valhallaUrl` / `externalServices.photonUrl`.
+
+## Minimal Example
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: pumperly.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+config:
+  defaultCountry: ES
+  enabledCountries: ES,FR,PT
+
+apiKeys:
+  tankerkoenig: your-key
+  openChargeMap: your-ocm-key
+
+valhalla:
+  enabled: true
+```
+
+Install with:
+
+```bash
+helm upgrade --install pumperly ./charts/pumperly -f my-values.yaml
+```
+
+## Useful Values
+
+- `existingSecret`: reuse an externally managed Secret
+  - always provide `DATABASE_URL`
+  - if `postgis.enabled=true`, also provide `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`
+  - optional API key entries: `TANKERKOENIG_API_KEY`, `PUMPERLY_OCM_API_KEY`, `FUELPRICES_DK_API_KEY`
+- `postgis.enabled`: disable bundled PostGIS for managed PostgreSQL/PostGIS
+- `databaseInit.enabled`: run `npx prisma db push` before the app starts
+- `externalServices.valhallaUrl`: use an external Valhalla instance
+- `externalServices.photonUrl`: use an external Photon instance
+- `extraEnv` / `extraEnvFrom`: inject additional app settings without editing templates

--- a/charts/pumperly/templates/NOTES.txt
+++ b/charts/pumperly/templates/NOTES.txt
@@ -16,9 +16,10 @@ Pumperly has been deployed successfully!
    Then access the UI at: http://127.0.0.1:3000/
 {{- end }}
 
+{{- if .Values.postgis.enabled }}
 2. PostGIS is running as a StatefulSet with the postgis/postgis image (spatial extensions included).
-{{- if not .Values.postgis.enabled }}
-   PostGIS is disabled. The chart expects an external database via existingSecret or externalDatabase values.
+{{- else }}
+2. PostGIS is disabled. The chart expects an external database via existingSecret or externalDatabase values.
 {{- end }}
 {{- if .Values.databaseInit.enabled }}
    Prisma schema sync is enabled through an initContainer on the web Deployment.

--- a/charts/pumperly/templates/NOTES.txt
+++ b/charts/pumperly/templates/NOTES.txt
@@ -1,0 +1,45 @@
+Pumperly has been deployed successfully!
+
+1. To access the Pumperly UI, follow these instructions:
+
+{{- if .Values.ingress.enabled }}
+   The Pumperly UI is accessible at:
+
+   {{- range .Values.ingress.hosts }}
+     http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (index .paths 0).path }}
+   {{- end }}
+{{- else }}
+   NOTE: The ingress is disabled. Use port-forwarding to access the UI:
+
+     kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "pumperly.fullname" . }} 3000:{{ .Values.service.port }}
+
+   Then access the UI at: http://127.0.0.1:3000/
+{{- end }}
+
+2. PostGIS is running as a StatefulSet with the postgis/postgis image (spatial extensions included).
+
+{{- if .Values.valhalla.enabled }}
+
+3. Valhalla routing engine is ENABLED.
+   - First startup will download and build routing tiles. This can take hours and requires ~15-24GB RAM.
+   - Tile URLs: {{ .Values.valhalla.tileUrls }}
+   - Once tiles are built, subsequent restarts are fast (tiles persist on the PVC).
+{{- else }}
+
+3. Valhalla routing engine is DISABLED. Enable it with:
+     --set valhalla.enabled=true
+{{- end }}
+
+{{- if .Values.photon.enabled }}
+
+4. Photon geocoder is ENABLED.
+   NOTE: Photon requires manual setup in v0.1.0. The chart creates skeleton resources
+   (Deployment, Service, PVC) but you must provide a custom image or ConfigMap with the
+   entrypoint script that downloads the Photon JAR and Nominatim data.
+   See: https://github.com/komoot/photon
+{{- else }}
+
+4. Photon geocoder is DISABLED. Enable it with:
+     --set photon.enabled=true
+   NOTE: Photon requires ~250GB disk and manual setup. See chart documentation.
+{{- end }}

--- a/charts/pumperly/templates/NOTES.txt
+++ b/charts/pumperly/templates/NOTES.txt
@@ -17,6 +17,12 @@ Pumperly has been deployed successfully!
 {{- end }}
 
 2. PostGIS is running as a StatefulSet with the postgis/postgis image (spatial extensions included).
+{{- if not .Values.postgis.enabled }}
+   PostGIS is disabled. The chart expects an external database via existingSecret or externalDatabase values.
+{{- end }}
+{{- if .Values.databaseInit.enabled }}
+   Prisma schema sync is enabled through an initContainer on the web Deployment.
+{{- end }}
 
 {{- if .Values.valhalla.enabled }}
 
@@ -33,13 +39,16 @@ Pumperly has been deployed successfully!
 {{- if .Values.photon.enabled }}
 
 4. Photon geocoder is ENABLED.
-   NOTE: Photon requires manual setup in v0.1.0. The chart creates skeleton resources
-   (Deployment, Service, PVC) but you must provide a custom image or ConfigMap with the
-   entrypoint script that downloads the Photon JAR and Nominatim data.
+   NOTE: Photon requires a working image plus command/args supplied in values.
+   The chart will not bootstrap Photon automatically for you.
    See: https://github.com/komoot/photon
 {{- else }}
 
 4. Photon geocoder is DISABLED. Enable it with:
      --set photon.enabled=true
-   NOTE: Photon requires ~250GB disk and manual setup. See chart documentation.
+   NOTE: Photon requires a prepared image/entrypoint and large persistent storage. See chart documentation.
 {{- end }}
+
+5. Scaling note:
+   Keep replicaCount=1 unless you intentionally disable or externalize scraping.
+   Pumperly starts in-process scrapers inside the web container.

--- a/charts/pumperly/templates/_helpers.tpl
+++ b/charts/pumperly/templates/_helpers.tpl
@@ -1,0 +1,121 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pumperly.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pumperly.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pumperly.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pumperly.labels" -}}
+helm.sh/chart: {{ include "pumperly.chart" . }}
+{{ include "pumperly.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pumperly.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pumperly.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+PostGIS selector labels
+*/}}
+{{- define "pumperly.postgis.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pumperly.name" . }}-postgis
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Valhalla selector labels
+*/}}
+{{- define "pumperly.valhalla.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pumperly.name" . }}-valhalla
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Photon selector labels
+*/}}
+{{- define "pumperly.photon.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pumperly.name" . }}-photon
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pumperly.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pumperly.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+PostGIS fully qualified name
+*/}}
+{{- define "pumperly.postgis.fullname" -}}
+{{- printf "%s-postgis" (include "pumperly.fullname" .) }}
+{{- end }}
+
+{{/*
+Valhalla fully qualified name
+*/}}
+{{- define "pumperly.valhalla.fullname" -}}
+{{- printf "%s-valhalla" (include "pumperly.fullname" .) }}
+{{- end }}
+
+{{/*
+Photon fully qualified name
+*/}}
+{{- define "pumperly.photon.fullname" -}}
+{{- printf "%s-photon" (include "pumperly.fullname" .) }}
+{{- end }}
+
+{{/*
+Secret name
+*/}}
+{{- define "pumperly.secretName" -}}
+{{- printf "%s-secret" (include "pumperly.fullname" .) }}
+{{- end }}
+
+{{/*
+Construct DATABASE_URL from postgis auth values
+*/}}
+{{- define "pumperly.databaseUrl" -}}
+{{- printf "postgresql://%s:%s@%s:5432/%s" .Values.postgis.auth.username .Values.postgis.auth.password (include "pumperly.postgis.fullname" .) .Values.postgis.auth.database }}
+{{- end }}

--- a/charts/pumperly/templates/_helpers.tpl
+++ b/charts/pumperly/templates/_helpers.tpl
@@ -51,6 +51,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Selector labels for the web application.
+*/}}
+{{- define "pumperly.webSelectorLabels" -}}
+{{ include "pumperly.selectorLabels" . }}
+app.kubernetes.io/component: web
+{{- end }}
+
+{{/*
 PostGIS selector labels
 */}}
 {{- define "pumperly.postgis.selectorLabels" -}}
@@ -110,12 +118,31 @@ Photon fully qualified name
 Secret name
 */}}
 {{- define "pumperly.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{- .Values.existingSecret -}}
+{{- else -}}
 {{- printf "%s-secret" (include "pumperly.fullname" .) }}
+{{- end -}}
 {{- end }}
 
 {{/*
-Construct DATABASE_URL from postgis auth values
+Database host
 */}}
-{{- define "pumperly.databaseUrl" -}}
-{{- printf "postgresql://%s:%s@%s:5432/%s" .Values.postgis.auth.username .Values.postgis.auth.password (include "pumperly.postgis.fullname" .) .Values.postgis.auth.database }}
-{{- end }}
+{{- define "pumperly.databaseHost" -}}
+{{- if .Values.postgis.enabled -}}
+{{- include "pumperly.postgis.fullname" . -}}
+{{- else -}}
+{{- .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database port
+*/}}
+{{- define "pumperly.databasePort" -}}
+{{- if .Values.postgis.enabled -}}
+5432
+{{- else -}}
+{{- .Values.externalDatabase.port -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pumperly/templates/deployment.yaml
+++ b/charts/pumperly/templates/deployment.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pumperly.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "pumperly.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pumperly.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pumperly.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: DATABASE_URL
+            {{- if .Values.config.defaultCountry }}
+            - name: PUMPERLY_DEFAULT_COUNTRY
+              value: {{ .Values.config.defaultCountry | quote }}
+            {{- end }}
+            {{- if .Values.config.enabledCountries }}
+            - name: PUMPERLY_ENABLED_COUNTRIES
+              value: {{ .Values.config.enabledCountries | quote }}
+            {{- end }}
+            {{- if .Values.config.defaultFuel }}
+            - name: PUMPERLY_DEFAULT_FUEL
+              value: {{ .Values.config.defaultFuel | quote }}
+            {{- end }}
+            {{- if .Values.config.corridorKm }}
+            - name: PUMPERLY_CORRIDOR_KM
+              value: {{ .Values.config.corridorKm | quote }}
+            {{- end }}
+            {{- if .Values.config.clusterStations }}
+            - name: PUMPERLY_CLUSTER_STATIONS
+              value: {{ .Values.config.clusterStations | quote }}
+            {{- end }}
+            {{- if .Values.config.scrapeIntervalHours }}
+            - name: PUMPERLY_SCRAPE_INTERVAL_HOURS
+              value: {{ .Values.config.scrapeIntervalHours | quote }}
+            {{- end }}
+            {{- if .Values.apiKeys.tankerkoenig }}
+            - name: PUMPERLY_TANKERKOENIG_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: PUMPERLY_TANKERKOENIG_API_KEY
+            {{- end }}
+            {{- if .Values.apiKeys.openChargeMap }}
+            - name: PUMPERLY_OPEN_CHARGE_MAP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: PUMPERLY_OPEN_CHARGE_MAP_API_KEY
+            {{- end }}
+            {{- if .Values.apiKeys.fuelpricesDk }}
+            - name: PUMPERLY_FUELPRICES_DK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: PUMPERLY_FUELPRICES_DK_API_KEY
+            {{- end }}
+            {{- if .Values.apiKeys.maxmind }}
+            - name: PUMPERLY_MAXMIND_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: PUMPERLY_MAXMIND_LICENSE_KEY
+            {{- end }}
+            {{- if .Values.valhalla.enabled }}
+            - name: PUMPERLY_VALHALLA_URL
+              value: "http://{{ include "pumperly.valhalla.fullname" . }}:8002"
+            {{- end }}
+            {{- if .Values.photon.enabled }}
+            - name: PUMPERLY_PHOTON_URL
+              value: "http://{{ include "pumperly.photon.fullname" . }}:2322"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.livenessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.readinessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/pumperly/templates/deployment.yaml
+++ b/charts/pumperly/templates/deployment.yaml
@@ -47,13 +47,21 @@ spec:
             - -ec
           args:
             - >-
+              deadline=$(( $(date +%s) + {{ .Values.waitForDatabase.timeoutSeconds }} ));
               until nc -z
               {{- if .Values.postgis.enabled }}
               {{ include "pumperly.databaseHost" . | quote }}
               {{- else }}
               {{ required "Set externalDatabase.host or disable waitForDatabase.enabled when postgis.enabled=false" .Values.externalDatabase.host | quote }}
               {{- end }}
-              {{ include "pumperly.databasePort" . | quote }}; do echo "waiting for database"; sleep 2; done
+              {{ include "pumperly.databasePort" . | quote }}; do
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "database did not become ready within {{ .Values.waitForDatabase.timeoutSeconds }} seconds";
+                  exit 1;
+                fi;
+                echo "waiting for database";
+                sleep 2;
+              done
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/pumperly/templates/deployment.yaml
+++ b/charts/pumperly/templates/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/component: web
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "pumperly.webSelectorLabels" . | nindent 6 }}
@@ -17,9 +19,14 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- if or (not .Values.existingSecret) .Values.podAnnotations }}
       annotations:
+        {{- if not .Values.existingSecret }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -39,7 +46,14 @@ spec:
             - /bin/sh
             - -ec
           args:
-            - until nc -z {{ include "pumperly.databaseHost" . | quote }} {{ include "pumperly.databasePort" . | quote }}; do echo "waiting for database"; sleep 2; done
+            - >-
+              until nc -z
+              {{- if .Values.postgis.enabled }}
+              {{ include "pumperly.databaseHost" . | quote }}
+              {{- else }}
+              {{ required "Set externalDatabase.host or disable waitForDatabase.enabled when postgis.enabled=false" .Values.externalDatabase.host | quote }}
+              {{- end }}
+              {{ include "pumperly.databasePort" . | quote }}; do echo "waiting for database"; sleep 2; done
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -48,6 +62,10 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
+          {{- with .Values.waitForDatabase.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.databaseInit.enabled }}
         - name: prisma-db-push
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -68,6 +86,12 @@ spec:
             capabilities:
               drop:
                 - ALL
+            runAsNonRoot: true
+            runAsUser: 1001
+          {{- with .Values.databaseInit.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- else if .Values.databaseInit.enabled }}
       initContainers:
@@ -90,6 +114,12 @@ spec:
             capabilities:
               drop:
                 - ALL
+            runAsNonRoot: true
+            runAsUser: 1001
+          {{- with .Values.databaseInit.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/pumperly/templates/deployment.yaml
+++ b/charts/pumperly/templates/deployment.yaml
@@ -4,27 +4,103 @@ metadata:
   name: {{ include "pumperly.fullname" . }}
   labels:
     {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "pumperly.selectorLabels" . | nindent 6 }}
+      {{- include "pumperly.webSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "pumperly.selectorLabels" . | nindent 8 }}
+        {{- include "pumperly.webSelectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "pumperly.serviceAccountName" . }}
+      {{- if .Values.waitForDatabase.enabled }}
+      initContainers:
+        - name: wait-for-database
+          image: {{ .Values.waitForDatabase.image | quote }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - until nc -z {{ include "pumperly.databaseHost" . | quote }} {{ include "pumperly.databasePort" . | quote }}; do echo "waiting for database"; sleep 2; done
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+        {{- if .Values.databaseInit.enabled }}
+        - name: prisma-db-push
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - npx prisma db push
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: DATABASE_URL
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        {{- end }}
+      {{- else if .Values.databaseInit.enabled }}
+      initContainers:
+        - name: prisma-db-push
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - npx prisma db push
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: DATABASE_URL
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
@@ -45,10 +121,6 @@ spec:
             - name: PUMPERLY_DEFAULT_FUEL
               value: {{ .Values.config.defaultFuel | quote }}
             {{- end }}
-            {{- if .Values.config.corridorKm }}
-            - name: PUMPERLY_CORRIDOR_KM
-              value: {{ .Values.config.corridorKm | quote }}
-            {{- end }}
             {{- if .Values.config.clusterStations }}
             - name: PUMPERLY_CLUSTER_STATIONS
               value: {{ .Values.config.clusterStations | quote }}
@@ -57,46 +129,61 @@ spec:
             - name: PUMPERLY_SCRAPE_INTERVAL_HOURS
               value: {{ .Values.config.scrapeIntervalHours | quote }}
             {{- end }}
+            {{- if .Values.config.evEnabled }}
+            - name: PUMPERLY_EV_ENABLED
+              value: {{ .Values.config.evEnabled | quote }}
+            {{- end }}
             {{- if .Values.apiKeys.tankerkoenig }}
-            - name: PUMPERLY_TANKERKOENIG_API_KEY
+            - name: TANKERKOENIG_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "pumperly.secretName" . }}
-                  key: PUMPERLY_TANKERKOENIG_API_KEY
+                  key: TANKERKOENIG_API_KEY
             {{- end }}
             {{- if .Values.apiKeys.openChargeMap }}
-            - name: PUMPERLY_OPEN_CHARGE_MAP_API_KEY
+            - name: PUMPERLY_OCM_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "pumperly.secretName" . }}
-                  key: PUMPERLY_OPEN_CHARGE_MAP_API_KEY
+                  key: PUMPERLY_OCM_API_KEY
             {{- end }}
             {{- if .Values.apiKeys.fuelpricesDk }}
-            - name: PUMPERLY_FUELPRICES_DK_API_KEY
+            - name: FUELPRICES_DK_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "pumperly.secretName" . }}
-                  key: PUMPERLY_FUELPRICES_DK_API_KEY
-            {{- end }}
-            {{- if .Values.apiKeys.maxmind }}
-            - name: PUMPERLY_MAXMIND_LICENSE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "pumperly.secretName" . }}
-                  key: PUMPERLY_MAXMIND_LICENSE_KEY
+                  key: FUELPRICES_DK_API_KEY
             {{- end }}
             {{- if .Values.valhalla.enabled }}
-            - name: PUMPERLY_VALHALLA_URL
+            - name: VALHALLA_URL
               value: "http://{{ include "pumperly.valhalla.fullname" . }}:8002"
+            {{- else if .Values.externalServices.valhallaUrl }}
+            - name: VALHALLA_URL
+              value: {{ .Values.externalServices.valhallaUrl | quote }}
             {{- end }}
             {{- if .Values.photon.enabled }}
-            - name: PUMPERLY_PHOTON_URL
+            - name: PHOTON_URL
               value: "http://{{ include "pumperly.photon.fullname" . }}:2322"
+            {{- else if .Values.externalServices.photonUrl }}
+            - name: PHOTON_URL
+              value: {{ .Values.externalServices.photonUrl | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.httpGet.path }}
+              port: {{ .Values.startupProbe.httpGet.port }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
@@ -117,8 +204,16 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/pumperly/templates/ingress.yaml
+++ b/charts/pumperly/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "pumperly.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- toYaml .hosts | nindent 8 }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "pumperly.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/pdb.yaml
+++ b/charts/pumperly/templates/pdb.yaml
@@ -8,8 +8,7 @@ metadata:
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:

--- a/charts/pumperly/templates/pdb.yaml
+++ b/charts/pumperly/templates/pdb.yaml
@@ -14,5 +14,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "pumperly.selectorLabels" . | nindent 6 }}
+      {{- include "pumperly.webSelectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/pumperly/templates/pdb.yaml
+++ b/charts/pumperly/templates/pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "pumperly.fullname" . }}
   labels:
     {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/pumperly/templates/pdb.yaml
+++ b/charts/pumperly/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pumperly.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pumperly.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/pumperly/templates/photon-deployment.yaml
+++ b/charts/pumperly/templates/photon-deployment.yaml
@@ -1,11 +1,4 @@
 {{- if .Values.photon.enabled }}
-# NOTE: Photon requires manual setup in v0.1.0.
-# The Photon geocoder uses a custom entrypoint that downloads and imports
-# Nominatim data. In Docker Compose this is handled via a shell script.
-# This chart creates the skeleton resources (Deployment, Service, PVC).
-# You must provide a ConfigMap with the entrypoint script or use a custom
-# image that bundles the Photon JAR and startup logic.
-# See: https://github.com/komoot/photon
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,16 +18,38 @@ spec:
       labels:
         {{- include "pumperly.photon.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: photon
+        {{- with .Values.photon.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.photon.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.photon.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: photon
-          image: "{{ .Values.photon.image.repository }}:{{ .Values.photon.image.tag }}"
+          image: "{{ required "Set photon.image.repository when photon.enabled=true" .Values.photon.image.repository }}:{{ required "Set photon.image.tag when photon.enabled=true" .Values.photon.image.tag }}"
           imagePullPolicy: IfNotPresent
-          env:
-            - name: PHOTON_COUNTRIES
-              value: {{ .Values.photon.countries | quote }}
-            - name: PHOTON_LANGUAGES
-              value: {{ .Values.photon.languages | quote }}
+          {{- with .Values.photon.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.photon.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.photon.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 2322
@@ -66,6 +81,18 @@ spec:
       volumes:
         - name: photon-data
           persistentVolumeClaim:
-            claimName: {{ include "pumperly.photon.fullname" . }}
+            claimName: {{ default (include "pumperly.photon.fullname" .) .Values.photon.persistence.existingClaim }}
+      {{- end }}
+      {{- with .Values.photon.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.photon.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.photon.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/pumperly/templates/photon-deployment.yaml
+++ b/charts/pumperly/templates/photon-deployment.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.photon.enabled }}
+# NOTE: Photon requires manual setup in v0.1.0.
+# The Photon geocoder uses a custom entrypoint that downloads and imports
+# Nominatim data. In Docker Compose this is handled via a shell script.
+# This chart creates the skeleton resources (Deployment, Service, PVC).
+# You must provide a ConfigMap with the entrypoint script or use a custom
+# image that bundles the Photon JAR and startup logic.
+# See: https://github.com/komoot/photon
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pumperly.photon.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: photon
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "pumperly.photon.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pumperly.photon.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: photon
+    spec:
+      containers:
+        - name: photon
+          image: "{{ .Values.photon.image.repository }}:{{ .Values.photon.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PHOTON_COUNTRIES
+              value: {{ .Values.photon.countries | quote }}
+            - name: PHOTON_LANGUAGES
+              value: {{ .Values.photon.languages | quote }}
+          ports:
+            - name: http
+              containerPort: 2322
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api?q=test
+              port: http
+            initialDelaySeconds: 300
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /api?q=test
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 20
+          {{- if .Values.photon.persistence.enabled }}
+          volumeMounts:
+            - name: photon-data
+              mountPath: /photon/photon_data
+          {{- end }}
+          resources:
+            {{- toYaml .Values.photon.resources | nindent 12 }}
+      {{- if .Values.photon.persistence.enabled }}
+      volumes:
+        - name: photon-data
+          persistentVolumeClaim:
+            claimName: {{ include "pumperly.photon.fullname" . }}
+      {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/photon-pvc.yaml
+++ b/charts/pumperly/templates/photon-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.photon.enabled .Values.photon.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pumperly.photon.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: photon
+spec:
+  accessModes:
+    {{- toYaml .Values.photon.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.photon.persistence.size }}
+  {{- if .Values.photon.persistence.storageClass }}
+  storageClassName: {{ .Values.photon.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/photon-pvc.yaml
+++ b/charts/pumperly/templates/photon-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.photon.enabled .Values.photon.persistence.enabled }}
+{{- if and .Values.photon.enabled .Values.photon.persistence.enabled (not .Values.photon.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/pumperly/templates/photon-service.yaml
+++ b/charts/pumperly/templates/photon-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.photon.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pumperly.photon.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: photon
+spec:
+  type: ClusterIP
+  ports:
+    - port: 2322
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "pumperly.photon.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/pumperly/templates/postgis-service.yaml
+++ b/charts/pumperly/templates/postgis-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgis.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
       name: postgresql
   selector:
     {{- include "pumperly.postgis.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/pumperly/templates/postgis-service.yaml
+++ b/charts/pumperly/templates/postgis-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pumperly.postgis.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgresql
+      protocol: TCP
+      name: postgresql
+  selector:
+    {{- include "pumperly.postgis.selectorLabels" . | nindent 4 }}

--- a/charts/pumperly/templates/postgis-statefulset.yaml
+++ b/charts/pumperly/templates/postgis-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgis.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -16,15 +17,30 @@ spec:
       labels:
         {{- include "pumperly.postgis.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: postgis
+        {{- with .Values.postgis.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.postgis.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgis.podSecurityContext }}
       securityContext:
-        fsGroup: 999
-        runAsNonRoot: true
-        runAsUser: 999
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgis
           image: "{{ .Values.postgis.image.repository }}:{{ .Values.postgis.image.tag }}"
           imagePullPolicy: IfNotPresent
+          {{- with .Values.postgis.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POSTGRES_USER
               valueFrom:
@@ -78,6 +94,18 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.postgis.resources | nindent 12 }}
+      {{- with .Values.postgis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   {{- if .Values.postgis.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
@@ -92,3 +120,4 @@ spec:
         storageClassName: {{ .Values.postgis.persistence.storageClass }}
         {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/postgis-statefulset.yaml
+++ b/charts/pumperly/templates/postgis-statefulset.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "pumperly.postgis.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgis
+spec:
+  serviceName: {{ include "pumperly.postgis.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "pumperly.postgis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pumperly.postgis.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgis
+    spec:
+      securityContext:
+        fsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 999
+      containers:
+        - name: postgis
+          image: "{{ .Values.postgis.image.repository }}:{{ .Values.postgis.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pumperly.secretName" . }}
+                  key: POSTGRES_DB
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgis.auth.username }}
+                - -d
+                - {{ .Values.postgis.auth.database }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgis.auth.username }}
+                - -d
+                - {{ .Values.postgis.auth.database }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          {{- if .Values.postgis.persistence.enabled }}
+          volumeMounts:
+            - name: postgis-data
+              mountPath: /var/lib/postgresql/data
+          {{- end }}
+          resources:
+            {{- toYaml .Values.postgis.resources | nindent 12 }}
+  {{- if .Values.postgis.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: postgis-data
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgis.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.postgis.persistence.size }}
+        {{- if .Values.postgis.persistence.storageClass }}
+        storageClassName: {{ .Values.postgis.persistence.storageClass }}
+        {{- end }}
+  {{- end }}

--- a/charts/pumperly/templates/secret.yaml
+++ b/charts/pumperly/templates/secret.yaml
@@ -1,24 +1,43 @@
+{{- if not .Values.existingSecret }}
+{{- $secretName := include "pumperly.secretName" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingPassword := "" }}
+{{- if $existing }}
+{{- $existingPassword = (index $existing.data "POSTGRES_PASSWORD" | default "" | b64dec) }}
+{{- end }}
+{{- $dbPassword := "" }}
+{{- $databaseUrl := "" }}
+{{- if .Values.postgis.enabled }}
+{{- $dbPassword = (.Values.postgis.auth.password | default $existingPassword | default (randAlphaNum 24)) }}
+{{- $databaseUrl = printf "postgresql://%s:%s@%s:5432/%s" .Values.postgis.auth.username $dbPassword (include "pumperly.postgis.fullname" .) .Values.postgis.auth.database }}
+{{- else if .Values.externalDatabase.url }}
+{{- $dbPassword = .Values.externalDatabase.password }}
+{{- $databaseUrl = .Values.externalDatabase.url }}
+{{- else }}
+{{- $dbPassword = (.Values.externalDatabase.password | default $existingPassword) }}
+{{- $databaseUrl = printf "postgresql://%s:%s@%s:%v/%s" .Values.externalDatabase.user $dbPassword .Values.externalDatabase.host .Values.externalDatabase.port .Values.externalDatabase.database }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "pumperly.secretName" . }}
+  name: {{ $secretName }}
   labels:
     {{- include "pumperly.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  DATABASE_URL: {{ include "pumperly.databaseUrl" . | quote }}
+  DATABASE_URL: {{ $databaseUrl | quote }}
+  {{- if .Values.postgis.enabled }}
   POSTGRES_USER: {{ .Values.postgis.auth.username | quote }}
-  POSTGRES_PASSWORD: {{ .Values.postgis.auth.password | quote }}
+  POSTGRES_PASSWORD: {{ $dbPassword | quote }}
   POSTGRES_DB: {{ .Values.postgis.auth.database | quote }}
+  {{- end }}
   {{- if .Values.apiKeys.tankerkoenig }}
-  PUMPERLY_TANKERKOENIG_API_KEY: {{ .Values.apiKeys.tankerkoenig | quote }}
+  TANKERKOENIG_API_KEY: {{ .Values.apiKeys.tankerkoenig | quote }}
   {{- end }}
   {{- if .Values.apiKeys.openChargeMap }}
-  PUMPERLY_OPEN_CHARGE_MAP_API_KEY: {{ .Values.apiKeys.openChargeMap | quote }}
+  PUMPERLY_OCM_API_KEY: {{ .Values.apiKeys.openChargeMap | quote }}
   {{- end }}
   {{- if .Values.apiKeys.fuelpricesDk }}
-  PUMPERLY_FUELPRICES_DK_API_KEY: {{ .Values.apiKeys.fuelpricesDk | quote }}
+  FUELPRICES_DK_API_KEY: {{ .Values.apiKeys.fuelpricesDk | quote }}
   {{- end }}
-  {{- if .Values.apiKeys.maxmind }}
-  PUMPERLY_MAXMIND_LICENSE_KEY: {{ .Values.apiKeys.maxmind | quote }}
-  {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/secret.yaml
+++ b/charts/pumperly/templates/secret.yaml
@@ -11,7 +11,6 @@
 {{- $dbPassword = (.Values.postgis.auth.password | default $existingPassword | default (randAlphaNum 24)) }}
 {{- $databaseUrl = printf "postgresql://%s:%s@%s:5432/%s" (.Values.postgis.auth.username | urlquery) ($dbPassword | urlquery) (include "pumperly.postgis.fullname" .) (.Values.postgis.auth.database | urlquery) }}
 {{- else if .Values.externalDatabase.url }}
-{{- $dbPassword = .Values.externalDatabase.password }}
 {{- $databaseUrl = .Values.externalDatabase.url }}
 {{- else }}
 {{- $dbPassword = (.Values.externalDatabase.password | default $existingPassword) }}

--- a/charts/pumperly/templates/secret.yaml
+++ b/charts/pumperly/templates/secret.yaml
@@ -9,13 +9,13 @@
 {{- $databaseUrl := "" }}
 {{- if .Values.postgis.enabled }}
 {{- $dbPassword = (.Values.postgis.auth.password | default $existingPassword | default (randAlphaNum 24)) }}
-{{- $databaseUrl = printf "postgresql://%s:%s@%s:5432/%s" (.Values.postgis.auth.username | urlquery) ($dbPassword | urlquery) (include "pumperly.postgis.fullname" .) .Values.postgis.auth.database }}
+{{- $databaseUrl = printf "postgresql://%s:%s@%s:5432/%s" (.Values.postgis.auth.username | urlquery) ($dbPassword | urlquery) (include "pumperly.postgis.fullname" .) (.Values.postgis.auth.database | urlquery) }}
 {{- else if .Values.externalDatabase.url }}
 {{- $dbPassword = .Values.externalDatabase.password }}
 {{- $databaseUrl = .Values.externalDatabase.url }}
 {{- else }}
 {{- $dbPassword = (.Values.externalDatabase.password | default $existingPassword) }}
-{{- $databaseUrl = printf "postgresql://%s:%s@%s:%v/%s" (required "Set externalDatabase.user when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.user | urlquery) ($dbPassword | urlquery) (required "Set externalDatabase.host when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.host) .Values.externalDatabase.port (required "Set externalDatabase.database when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.database) }}
+{{- $databaseUrl = printf "postgresql://%s:%s@%s:%v/%s" (required "Set externalDatabase.user when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.user | urlquery) ($dbPassword | urlquery) (required "Set externalDatabase.host when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.host) .Values.externalDatabase.port (required "Set externalDatabase.database when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.database | urlquery) }}
 {{- end }}
 apiVersion: v1
 kind: Secret

--- a/charts/pumperly/templates/secret.yaml
+++ b/charts/pumperly/templates/secret.yaml
@@ -9,13 +9,13 @@
 {{- $databaseUrl := "" }}
 {{- if .Values.postgis.enabled }}
 {{- $dbPassword = (.Values.postgis.auth.password | default $existingPassword | default (randAlphaNum 24)) }}
-{{- $databaseUrl = printf "postgresql://%s:%s@%s:5432/%s" .Values.postgis.auth.username $dbPassword (include "pumperly.postgis.fullname" .) .Values.postgis.auth.database }}
+{{- $databaseUrl = printf "postgresql://%s:%s@%s:5432/%s" (.Values.postgis.auth.username | urlquery) ($dbPassword | urlquery) (include "pumperly.postgis.fullname" .) .Values.postgis.auth.database }}
 {{- else if .Values.externalDatabase.url }}
 {{- $dbPassword = .Values.externalDatabase.password }}
 {{- $databaseUrl = .Values.externalDatabase.url }}
 {{- else }}
 {{- $dbPassword = (.Values.externalDatabase.password | default $existingPassword) }}
-{{- $databaseUrl = printf "postgresql://%s:%s@%s:%v/%s" .Values.externalDatabase.user $dbPassword .Values.externalDatabase.host .Values.externalDatabase.port .Values.externalDatabase.database }}
+{{- $databaseUrl = printf "postgresql://%s:%s@%s:%v/%s" (required "Set externalDatabase.user when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.user | urlquery) ($dbPassword | urlquery) (required "Set externalDatabase.host when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.host) .Values.externalDatabase.port (required "Set externalDatabase.database when postgis.enabled=false and externalDatabase.url is empty" .Values.externalDatabase.database) }}
 {{- end }}
 apiVersion: v1
 kind: Secret

--- a/charts/pumperly/templates/secret.yaml
+++ b/charts/pumperly/templates/secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pumperly.secretName" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DATABASE_URL: {{ include "pumperly.databaseUrl" . | quote }}
+  POSTGRES_USER: {{ .Values.postgis.auth.username | quote }}
+  POSTGRES_PASSWORD: {{ .Values.postgis.auth.password | quote }}
+  POSTGRES_DB: {{ .Values.postgis.auth.database | quote }}
+  {{- if .Values.apiKeys.tankerkoenig }}
+  PUMPERLY_TANKERKOENIG_API_KEY: {{ .Values.apiKeys.tankerkoenig | quote }}
+  {{- end }}
+  {{- if .Values.apiKeys.openChargeMap }}
+  PUMPERLY_OPEN_CHARGE_MAP_API_KEY: {{ .Values.apiKeys.openChargeMap | quote }}
+  {{- end }}
+  {{- if .Values.apiKeys.fuelpricesDk }}
+  PUMPERLY_FUELPRICES_DK_API_KEY: {{ .Values.apiKeys.fuelpricesDk | quote }}
+  {{- end }}
+  {{- if .Values.apiKeys.maxmind }}
+  PUMPERLY_MAXMIND_LICENSE_KEY: {{ .Values.apiKeys.maxmind | quote }}
+  {{- end }}

--- a/charts/pumperly/templates/service.yaml
+++ b/charts/pumperly/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "pumperly.fullname" . }}
   labels:
     {{- include "pumperly.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,4 +16,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "pumperly.selectorLabels" . | nindent 4 }}
+    {{- include "pumperly.webSelectorLabels" . | nindent 4 }}

--- a/charts/pumperly/templates/service.yaml
+++ b/charts/pumperly/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pumperly.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "pumperly.selectorLabels" . | nindent 4 }}

--- a/charts/pumperly/templates/serviceaccount.yaml
+++ b/charts/pumperly/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: false
 {{- end }}

--- a/charts/pumperly/templates/serviceaccount.yaml
+++ b/charts/pumperly/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pumperly.serviceAccountName" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/tests/test-connection.yaml
+++ b/charts/pumperly/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "pumperly.fullname" . }}-test-connection"
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  containers:
+    - name: wget
+      image: busybox:latest
+      command: ['wget']
+      args: ['--spider', '--quiet', 'http://{{ include "pumperly.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/pumperly/templates/tests/test-connection.yaml
+++ b/charts/pumperly/templates/tests/test-connection.yaml
@@ -9,9 +9,21 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  automountServiceAccountToken: false
   containers:
     - name: wget
-      image: busybox:latest
-      command: ['wget']
-      args: ['--spider', '--quiet', 'http://{{ include "pumperly.fullname" . }}:{{ .Values.service.port }}']
+      image: busybox:1.36.1
+      command:
+        - /bin/sh
+        - -ec
+      args:
+        - wget --spider --quiet "http://{{ include "pumperly.fullname" . }}:{{ .Values.service.port }}/api/config"
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
   restartPolicy: Never

--- a/charts/pumperly/templates/valhalla-deployment.yaml
+++ b/charts/pumperly/templates/valhalla-deployment.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.valhalla.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pumperly.valhalla.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valhalla
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "pumperly.valhalla.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pumperly.valhalla.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: valhalla
+    spec:
+      containers:
+        - name: valhalla
+          image: "{{ .Values.valhalla.image.repository }}:{{ .Values.valhalla.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: tile_urls
+              value: {{ .Values.valhalla.tileUrls | quote }}
+            - name: server_threads
+              value: {{ .Values.valhalla.serverThreads | quote }}
+            - name: build_admins
+              value: {{ .Values.valhalla.buildAdmins | quote }}
+            - name: build_time_zones
+              value: {{ .Values.valhalla.buildTimeZones | quote }}
+          ports:
+            - name: http
+              containerPort: 8002
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 10
+          {{- if .Values.valhalla.persistence.enabled }}
+          volumeMounts:
+            - name: valhalla-data
+              mountPath: /custom_files
+          {{- end }}
+          resources:
+            {{- toYaml .Values.valhalla.resources | nindent 12 }}
+      {{- if .Values.valhalla.persistence.enabled }}
+      volumes:
+        - name: valhalla-data
+          persistentVolumeClaim:
+            claimName: {{ include "pumperly.valhalla.fullname" . }}
+      {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/valhalla-deployment.yaml
+++ b/charts/pumperly/templates/valhalla-deployment.yaml
@@ -18,11 +18,30 @@ spec:
       labels:
         {{- include "pumperly.valhalla.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: valhalla
+        {{- with .Values.valhalla.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.valhalla.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.valhalla.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: valhalla
           image: "{{ .Values.valhalla.image.repository }}:{{ .Values.valhalla.image.tag }}"
           imagePullPolicy: IfNotPresent
+          {{- with .Values.valhalla.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: tile_urls
               value: {{ .Values.valhalla.tileUrls | quote }}
@@ -63,6 +82,18 @@ spec:
       volumes:
         - name: valhalla-data
           persistentVolumeClaim:
-            claimName: {{ include "pumperly.valhalla.fullname" . }}
+            claimName: {{ default (include "pumperly.valhalla.fullname" .) .Values.valhalla.persistence.existingClaim }}
+      {{- end }}
+      {{- with .Values.valhalla.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.valhalla.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.valhalla.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/pumperly/templates/valhalla-pvc.yaml
+++ b/charts/pumperly/templates/valhalla-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.valhalla.enabled .Values.valhalla.persistence.enabled }}
+{{- if and .Values.valhalla.enabled .Values.valhalla.persistence.enabled (not .Values.valhalla.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/pumperly/templates/valhalla-pvc.yaml
+++ b/charts/pumperly/templates/valhalla-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.valhalla.enabled .Values.valhalla.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pumperly.valhalla.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valhalla
+spec:
+  accessModes:
+    {{- toYaml .Values.valhalla.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.valhalla.persistence.size }}
+  {{- if .Values.valhalla.persistence.storageClass }}
+  storageClassName: {{ .Values.valhalla.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/pumperly/templates/valhalla-service.yaml
+++ b/charts/pumperly/templates/valhalla-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.valhalla.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pumperly.valhalla.fullname" . }}
+  labels:
+    {{- include "pumperly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valhalla
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8002
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "pumperly.valhalla.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/pumperly/values.schema.json
+++ b/charts/pumperly/values.schema.json
@@ -249,6 +249,10 @@
         "image": {
           "type": "string"
         },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
         "resources": {
           "type": "object"
         }

--- a/charts/pumperly/values.schema.json
+++ b/charts/pumperly/values.schema.json
@@ -1,0 +1,519 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "defaultCountry": {
+          "type": "string"
+        },
+        "enabledCountries": {
+          "type": "string"
+        },
+        "defaultFuel": {
+          "type": "string"
+        },
+        "clusterStations": {
+          "type": "string"
+        },
+        "scrapeIntervalHours": {
+          "type": "string"
+        },
+        "evEnabled": {
+          "type": "string"
+        }
+      }
+    },
+    "apiKeys": {
+      "type": "object",
+      "properties": {
+        "tankerkoenig": {
+          "type": "string"
+        },
+        "openChargeMap": {
+          "type": "string"
+        },
+        "fuelpricesDk": {
+          "type": "string"
+        }
+      }
+    },
+    "existingSecret": {
+      "type": "string"
+    },
+    "externalServices": {
+      "type": "object",
+      "properties": {
+        "valhallaUrl": {
+          "type": "string"
+        },
+        "photonUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "postgis": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "size": {
+              "type": "string"
+            },
+            "accessModes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "affinity": {
+          "type": "object"
+        }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        }
+      }
+    },
+    "waitForDatabase": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "string"
+        }
+      }
+    },
+    "databaseInit": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "valhalla": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "tileUrls": {
+          "type": "string"
+        },
+        "serverThreads": {
+          "type": "string"
+        },
+        "buildAdmins": {
+          "type": "string"
+        },
+        "buildTimeZones": {
+          "type": "string"
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            },
+            "accessModes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "affinity": {
+          "type": "object"
+        }
+      }
+    },
+    "photon": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            },
+            "accessModes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "affinity": {
+          "type": "object"
+        }
+      }
+    },
+    "resources": {
+      "type": "object"
+    },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": ["integer", "string"]
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string"]
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object"
+    }
+  }
+}

--- a/charts/pumperly/values.schema.json
+++ b/charts/pumperly/values.schema.json
@@ -32,6 +32,15 @@
       "type": "integer",
       "minimum": 1
     },
+    "deploymentStrategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["Recreate", "RollingUpdate"]
+        }
+      }
+    },
     "service": {
       "type": "object",
       "properties": {
@@ -239,6 +248,9 @@
         },
         "image": {
           "type": "string"
+        },
+        "resources": {
+          "type": "object"
         }
       }
     },
@@ -247,6 +259,9 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "resources": {
+          "type": "object"
         }
       }
     },
@@ -420,6 +435,29 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": ["string", "integer"]
+            }
+          }
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     },
@@ -428,6 +466,33 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": ["string", "integer"]
+            }
+          }
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     },
@@ -436,6 +501,33 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": ["string", "integer"]
+            }
+          }
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     },

--- a/charts/pumperly/values.yaml
+++ b/charts/pumperly/values.yaml
@@ -1,13 +1,19 @@
+nameOverride: ""
+fullnameOverride: ""
+
 image:
   repository: drumsergio/pumperly
   pullPolicy: IfNotPresent
   tag: "1.2.0"
+
+imagePullSecrets: []
 
 replicaCount: 1
 
 service:
   type: ClusterIP
   port: 3000
+  annotations: {}
 
 ingress:
   enabled: false
@@ -17,43 +23,71 @@ ingress:
     - host: pumperly.local
       paths:
         - path: /
-          pathType: ImplementationSpecific
+          pathType: Prefix
   tls: []
 
 config:
   defaultCountry: "ES"
-  enabledCountries: ""  # Empty = all countries
+  enabledCountries: ""
   defaultFuel: ""
-  corridorKm: "5"
   clusterStations: "true"
   scrapeIntervalHours: ""
+  evEnabled: ""
 
 apiKeys:
-  tankerkoenig: ""      # Germany fuel prices
-  openChargeMap: ""      # EV charging data
-  fuelpricesDk: ""       # Denmark fuel prices
-  maxmind: ""            # IP geolocation
+  tankerkoenig: ""
+  openChargeMap: ""
+  fuelpricesDk: ""
+
+existingSecret: ""
+
+externalServices:
+  valhallaUrl: ""
+  photonUrl: ""
 
 postgis:
+  enabled: true
   image:
     repository: postgis/postgis
     tag: "17-3.4-alpine"
   auth:
     username: pumperly
-    password: pumperly
+    password: ""
     database: pumperly
   persistence:
     enabled: true
     size: 5Gi
     accessModes:
       - ReadWriteOnce
-    # storageClass: ""
+    storageClass: ""
   resources:
     requests:
       cpu: 250m
       memory: 512Mi
     limits:
       memory: 4Gi
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+externalDatabase:
+  url: ""
+  host: ""
+  port: 5432
+  user: ""
+  password: ""
+  database: ""
+
+waitForDatabase:
+  enabled: true
+  image: busybox:1.36.1
+
+databaseInit:
+  enabled: true
 
 valhalla:
   enabled: false
@@ -66,36 +100,52 @@ valhalla:
   buildTimeZones: "True"
   persistence:
     enabled: true
+    existingClaim: ""
     size: 100Gi
     accessModes:
       - ReadWriteOnce
-    # storageClass: ""
+    storageClass: ""
   resources:
     requests:
       cpu: 1000m
       memory: 4Gi
     limits:
-      memory: 24Gi  # Tile building peaks at ~15-24GB
+      memory: 24Gi
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 photon:
   enabled: false
   image:
-    repository: eclipse-temurin
-    tag: "21-jre"
-  countries: "spain"  # Comma-separated list
-  languages: "es,en,fr,de"
+    repository: ""
+    tag: ""
+  command: []
+  args: []
   persistence:
     enabled: true
+    existingClaim: ""
     size: 300Gi
     accessModes:
       - ReadWriteOnce
-    # storageClass: ""
+    storageClass: ""
   resources:
     requests:
       cpu: 500m
       memory: 2Gi
     limits:
       memory: 8Gi
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 resources:
   requests:
@@ -104,10 +154,19 @@ resources:
   limits:
     memory: 1Gi
 
+startupProbe:
+  enabled: true
+  httpGet:
+    path: /api/config
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+
 livenessProbe:
   enabled: true
   httpGet:
-    path: /
+    path: /api/config
     port: http
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -117,9 +176,9 @@ livenessProbe:
 readinessProbe:
   enabled: true
   httpGet:
-    path: /
+    path: /api/config
     port: http
-  initialDelaySeconds: 15
+  initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
@@ -145,8 +204,14 @@ podDisruptionBudget:
   minAvailable: 1
   # maxUnavailable: 1
 
+podAnnotations: {}
+podLabels: {}
+
+extraEnv: []
+extraEnvFrom: []
+extraVolumes: []
+extraVolumeMounts: []
+
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}

--- a/charts/pumperly/values.yaml
+++ b/charts/pumperly/values.yaml
@@ -1,0 +1,152 @@
+image:
+  repository: drumsergio/pumperly
+  pullPolicy: IfNotPresent
+  tag: "1.2.0"
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: pumperly.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+config:
+  defaultCountry: "ES"
+  enabledCountries: ""  # Empty = all countries
+  defaultFuel: ""
+  corridorKm: "5"
+  clusterStations: "true"
+  scrapeIntervalHours: ""
+
+apiKeys:
+  tankerkoenig: ""      # Germany fuel prices
+  openChargeMap: ""      # EV charging data
+  fuelpricesDk: ""       # Denmark fuel prices
+  maxmind: ""            # IP geolocation
+
+postgis:
+  image:
+    repository: postgis/postgis
+    tag: "17-3.4-alpine"
+  auth:
+    username: pumperly
+    password: pumperly
+    database: pumperly
+  persistence:
+    enabled: true
+    size: 5Gi
+    accessModes:
+      - ReadWriteOnce
+    # storageClass: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      memory: 4Gi
+
+valhalla:
+  enabled: false
+  image:
+    repository: ghcr.io/gis-ops/docker-valhalla/valhalla
+    tag: "3.5.1"
+  tileUrls: "https://download.geofabrik.de/europe/spain-latest.osm.pbf"
+  serverThreads: "4"
+  buildAdmins: "True"
+  buildTimeZones: "True"
+  persistence:
+    enabled: true
+    size: 100Gi
+    accessModes:
+      - ReadWriteOnce
+    # storageClass: ""
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 4Gi
+    limits:
+      memory: 24Gi  # Tile building peaks at ~15-24GB
+
+photon:
+  enabled: false
+  image:
+    repository: eclipse-temurin
+    tag: "21-jre"
+  countries: "spain"  # Comma-separated list
+  languages: "es,en,fr,de"
+  persistence:
+    enabled: true
+    size: 300Gi
+    accessModes:
+      - ReadWriteOnce
+    # storageClass: ""
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      memory: 8Gi
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+podSecurityContext:
+  fsGroup: 1001
+  runAsNonRoot: true
+  runAsUser: 1001
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/pumperly/values.yaml
+++ b/charts/pumperly/values.yaml
@@ -10,6 +10,9 @@ imagePullSecrets: []
 
 replicaCount: 1
 
+deploymentStrategy:
+  type: Recreate
+
 service:
   type: ClusterIP
   port: 3000
@@ -85,9 +88,11 @@ externalDatabase:
 waitForDatabase:
   enabled: true
   image: busybox:1.36.1
+  resources: {}
 
 databaseInit:
   enabled: true
+  resources: {}
 
 valhalla:
   enabled: false

--- a/charts/pumperly/values.yaml
+++ b/charts/pumperly/values.yaml
@@ -88,6 +88,7 @@ externalDatabase:
 waitForDatabase:
   enabled: true
   image: busybox:1.36.1
+  timeoutSeconds: 300
   resources: {}
 
 databaseInit:


### PR DESCRIPTION
## Summary
- Adds a comprehensive Helm chart at `charts/pumperly/` for deploying Pumperly on Kubernetes
- Includes PostGIS StatefulSet (with spatial extensions), optional Valhalla routing engine, and optional Photon geocoder
- Configurable via `values.yaml` with sensible defaults — all components toggleable
- Includes ServiceAccount, Ingress, PVCs, health probes, security contexts, and PodDisruptionBudget

## Components
- **Pumperly app** (Deployment) — Next.js application
- **PostGIS** (StatefulSet) — PostgreSQL with spatial extensions, persistent storage
- **Valhalla** (StatefulSet, optional) — Turn-by-turn routing engine with large PVC for tile data
- **Photon** (Deployment, optional) — Geocoding service backed by OpenStreetMap

## Test plan
- [ ] `helm template` renders without errors
- [ ] Deploy with only PostGIS enabled (default)
- [ ] Deploy with Valhalla enabled and verify routing
- [ ] Deploy with Photon enabled and verify geocoding
- [ ] Verify Ingress and TLS configuration
- [ ] Test with external database (`postgis.enabled: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)