### PR TITLE
docs: document databaseInit as single-replica concern

### DIFF
--- a/charts/pumperly/templates/deployment.yaml
+++ b/charts/pumperly/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.databaseInit.enabled (gt (int .Values.replicaCount) 1) }}
+{{- fail "databaseInit.enabled=true with replicaCount > 1 will run concurrent schema migrations. Set databaseInit.enabled=false and run migrations out-of-band, or keep replicaCount=1." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/pumperly/values.yaml
+++ b/charts/pumperly/values.yaml
@@ -91,6 +91,9 @@ waitForDatabase:
   timeoutSeconds: 300
   resources: {}
 
+# -- Runs `npx prisma db push` as an init container on every pod start.
+# -- Safe for single-replica homelab deploys. Disable for HA or strict
+# -- rollout processes where schema mutations should be a separate step.
 databaseInit:
   enabled: true
   resources: {}


### PR DESCRIPTION
## Summary
- Add values.yaml comment clarifying that `databaseInit.enabled: true` runs `npx prisma db push` on every pod start
- Documents this as safe for single-replica homelab deploys but a concern for HA/strict rollout processes

## Test plan
- [ ] `helm lint` passes
- [ ] `helm template` renders cleanly