### PR TITLE
fix: remove corridor station sampling that dropped stations

### DIFF
--- a/src/app/api/route-stations/route.ts
+++ b/src/app/api/route-stations/route.ts
@@ -10,7 +10,7 @@ const VALID_FUEL_TYPES = [
 ] as const;
 
 const MAX_COORDINATES = 2000;
-const MAX_RESULTS = 500;
+const MAX_RESULTS = 5000;
 
 const bodySchema = z.object({
   geometry: z.object({
@@ -62,84 +62,71 @@ export async function POST(request: NextRequest) {
     const routeGeom = `ST_GeomFromText($1, 4326)`;
     const isEV = fuel === "EV";
 
-    // Use CTE with ROW_NUMBER to sample uniformly along the route when
-    // results exceed MAX_RESULTS, avoiding start-of-route bias.
+    // Return corridor stations without sampling. The old CTE sampler uniformly
+    // dropped every Nth station, causing per-route inconsistencies (a station
+    // could survive on one alternative but be dropped from the selected route).
+    // A hard LIMIT (MAX_RESULTS) is kept as a safety ceiling; if it ever
+    // triggers, only the tail end of the route is truncated.
     const rows: StationRow[] = isEV
       ? await prisma.$queryRawUnsafe(
           `
-          WITH candidates AS (
-            SELECT
-              s.id,
-              s.name,
-              s.brand,
-              s.address,
-              s.city,
-              ST_X(s.geom) AS longitude,
-              ST_Y(s.geom) AS latitude,
-              NULL::float AS price,
-              'EUR' AS currency,
-              NULL::timestamptz AS reported_at,
-              ST_LineLocatePoint(${routeGeom}, s.geom)::float AS route_fraction,
-              ST_Distance(s.geom::geography, ${routeGeom}::geography)::float AS distance_m,
-              ROW_NUMBER() OVER (ORDER BY ST_LineLocatePoint(${routeGeom}, s.geom)) AS rn,
-              COUNT(*) OVER () AS total
-            FROM stations s
-            WHERE s.station_type IN ('ev_charger', 'both')
-              AND ST_DWithin(
-                s.geom::geography,
-                ${routeGeom}::geography,
-                $2
-              )
-          )
-          SELECT id, name, brand, address, city, longitude, latitude,
-                 price, currency, reported_at, route_fraction, distance_m
-          FROM candidates
-          WHERE total <= ${MAX_RESULTS}
-             OR (rn - 1) % GREATEST(1, CEIL(total::float / ${MAX_RESULTS})::int) = 0
+          SELECT
+            s.id,
+            s.name,
+            s.brand,
+            s.address,
+            s.city,
+            ST_X(s.geom) AS longitude,
+            ST_Y(s.geom) AS latitude,
+            NULL::float AS price,
+            'EUR' AS currency,
+            NULL::timestamptz AS reported_at,
+            ST_LineLocatePoint(${routeGeom}, s.geom)::float AS route_fraction,
+            ST_Distance(s.geom::geography, ${routeGeom}::geography)::float AS distance_m
+          FROM stations s
+          WHERE s.station_type IN ('ev_charger', 'both')
+            AND ST_DWithin(
+              s.geom::geography,
+              ${routeGeom}::geography,
+              $2
+            )
           ORDER BY route_fraction
+          LIMIT ${MAX_RESULTS}
           `,
           wkt,
           corridorMeters,
         )
       : await prisma.$queryRawUnsafe(
           `
-          WITH candidates AS (
-            SELECT
-              s.id,
-              s.name,
-              s.brand,
-              s.address,
-              s.city,
-              ST_X(s.geom) AS longitude,
-              ST_Y(s.geom) AS latitude,
-              fp.price::float AS price,
-              COALESCE(fp.currency, 'EUR') AS currency,
-              fp.reported_at,
-              ST_LineLocatePoint(${routeGeom}, s.geom)::float AS route_fraction,
-              ST_Distance(s.geom::geography, ${routeGeom}::geography)::float AS distance_m,
-              ROW_NUMBER() OVER (ORDER BY ST_LineLocatePoint(${routeGeom}, s.geom)) AS rn,
-              COUNT(*) OVER () AS total
-            FROM stations s
-            JOIN LATERAL (
-              SELECT price, currency, reported_at
-              FROM fuel_prices
-              WHERE station_id = s.id
-                AND fuel_type = $3
-              ORDER BY reported_at DESC NULLS LAST
-              LIMIT 1
-            ) fp ON true
-            WHERE ST_DWithin(
-              s.geom::geography,
-              ${routeGeom}::geography,
-              $2
-            )
+          SELECT
+            s.id,
+            s.name,
+            s.brand,
+            s.address,
+            s.city,
+            ST_X(s.geom) AS longitude,
+            ST_Y(s.geom) AS latitude,
+            fp.price::float AS price,
+            COALESCE(fp.currency, 'EUR') AS currency,
+            fp.reported_at,
+            ST_LineLocatePoint(${routeGeom}, s.geom)::float AS route_fraction,
+            ST_Distance(s.geom::geography, ${routeGeom}::geography)::float AS distance_m
+          FROM stations s
+          JOIN LATERAL (
+            SELECT price, currency, reported_at
+            FROM fuel_prices
+            WHERE station_id = s.id
+              AND fuel_type = $3
+            ORDER BY reported_at DESC NULLS LAST
+            LIMIT 1
+          ) fp ON true
+          WHERE ST_DWithin(
+            s.geom::geography,
+            ${routeGeom}::geography,
+            $2
           )
-          SELECT id, name, brand, address, city, longitude, latitude,
-                 price, currency, reported_at, route_fraction, distance_m
-          FROM candidates
-          WHERE total <= ${MAX_RESULTS}
-             OR (rn - 1) % GREATEST(1, CEIL(total::float / ${MAX_RESULTS})::int) = 0
           ORDER BY route_fraction
+          LIMIT ${MAX_RESULTS}
           `,
           wkt,
           corridorMeters,


### PR DESCRIPTION
## Summary
- Removes the CTE-based uniform sampling from `/api/route-stations` that capped results at 500 (later 2000)
- On long routes (e.g. Sangüesa → Murcia), the corridor can contain 600+ stations. The sampler dropped every Nth station per route independently — a station could survive on one alternative but get sampled out of the selected route
- This caused stations to appear on the map (merged across all routes) but be missing from the "stations along route" sidebar (per-route only)
- The corridor geometry (`ST_DWithin`) already bounds results geographically, making the sampler unnecessary

## Repro
Route from Zangoza (Sangüesa) to Murcia → station in Erla at 1.60€ visible on map but missing from sidebar

## Test plan
- [ ] Route Sangüesa → Murcia, verify Erla station appears in sidebar
- [ ] Long routes (500+ km) return all corridor stations without gaps
- [ ] Short routes unaffected (corridor returns few stations, no sampling was triggered anyway)
- [ ] Build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route station search now returns many more stations (result cap increased to 5000) and no longer down-samples results, so users see a more complete set along the corridor.
  * Stations are ordered by their position along the route; non-EV searches continue to show the latest fuel price per station.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->