### PR TITLE
fix: split long route geometries into segments for ST_DWithin

### DIFF
--- a/src/app/api/route-stations/route.ts
+++ b/src/app/api/route-stations/route.ts
@@ -11,6 +11,11 @@ const VALID_FUEL_TYPES = [
 
 const MAX_COORDINATES = 2000;
 const MAX_RESULTS = 5000;
+// PostGIS ST_DWithin on geography silently misses matches when the LineString
+// has too many vertices (observed with 2000-point, 670km+ routes). Splitting
+// into shorter segments and merging results works around this.
+const SEGMENT_SIZE = 200;
+const SEGMENT_OVERLAP = 20;
 
 const bodySchema = z.object({
   geometry: z.object({
@@ -54,84 +59,110 @@ export async function POST(request: NextRequest) {
 
   const { geometry, fuel, corridorKm } = parseResult.data;
 
-  // Convert GeoJSON coordinates to WKT LineString
-  const wkt = `LINESTRING(${geometry.coordinates.map(([lon, lat]) => `${lon} ${lat}`).join(",")})`;
+  const coords = geometry.coordinates;
   const corridorMeters = corridorKm * 1000;
+  const isEV = fuel === "EV";
+
+  // Split long LineStrings into overlapping segments to work around PostGIS
+  // ST_DWithin(geography) accuracy issues with high-vertex-count geometries.
+  const segments: [number, number][][] = [];
+  if (coords.length <= SEGMENT_SIZE) {
+    segments.push(coords);
+  } else {
+    for (let start = 0; start < coords.length; start += SEGMENT_SIZE - SEGMENT_OVERLAP) {
+      const end = Math.min(start + SEGMENT_SIZE, coords.length);
+      segments.push(coords.slice(start, end));
+      if (end === coords.length) break;
+    }
+  }
+
+  const fullWkt = `LINESTRING(${coords.map(([lon, lat]) => `${lon} ${lat}`).join(",")})`;
 
   try {
-    const routeGeom = `ST_GeomFromText($1, 4326)`;
-    const isEV = fuel === "EV";
-
-    // Return corridor stations without sampling. The old CTE sampler uniformly
-    // dropped every Nth station, causing per-route inconsistencies (a station
-    // could survive on one alternative but be dropped from the selected route).
-    // A hard LIMIT (MAX_RESULTS) is kept as a safety ceiling; if it ever
-    // triggers, only the tail end of the route is truncated.
-    const rows: StationRow[] = isEV
-      ? await prisma.$queryRawUnsafe(
-          `
-          SELECT
-            s.id,
-            s.name,
-            s.brand,
-            s.address,
-            s.city,
-            ST_X(s.geom) AS longitude,
-            ST_Y(s.geom) AS latitude,
-            NULL::float AS price,
-            'EUR' AS currency,
-            NULL::timestamptz AS reported_at,
-            ST_LineLocatePoint(${routeGeom}, s.geom)::float AS route_fraction,
-            ST_Distance(s.geom::geography, ${routeGeom}::geography)::float AS distance_m
-          FROM stations s
-          WHERE s.station_type IN ('ev_charger', 'both')
-            AND ST_DWithin(
-              s.geom::geography,
-              ${routeGeom}::geography,
-              $2
+    // Query each segment in parallel, then deduplicate
+    const segmentResults = await Promise.all(
+      segments.map((seg) => {
+        const segWkt = `LINESTRING(${seg.map(([lon, lat]) => `${lon} ${lat}`).join(",")})`;
+        const segGeom = `ST_GeomFromText($1, 4326)`;
+        return isEV
+          ? prisma.$queryRawUnsafe<StationRow[]>(
+              `
+              SELECT
+                s.id, s.name, s.brand, s.address, s.city,
+                ST_X(s.geom) AS longitude, ST_Y(s.geom) AS latitude,
+                NULL::float AS price, 'EUR' AS currency,
+                NULL::timestamptz AS reported_at,
+                0::float AS route_fraction,
+                0::float AS distance_m
+              FROM stations s
+              WHERE s.station_type IN ('ev_charger', 'both')
+                AND ST_DWithin(s.geom::geography, ${segGeom}::geography, $2)
+              `,
+              segWkt,
+              corridorMeters,
             )
-          ORDER BY route_fraction
-          LIMIT ${MAX_RESULTS}
-          `,
-          wkt,
-          corridorMeters,
-        )
-      : await prisma.$queryRawUnsafe(
-          `
-          SELECT
-            s.id,
-            s.name,
-            s.brand,
-            s.address,
-            s.city,
-            ST_X(s.geom) AS longitude,
-            ST_Y(s.geom) AS latitude,
-            fp.price::float AS price,
-            COALESCE(fp.currency, 'EUR') AS currency,
-            fp.reported_at,
-            ST_LineLocatePoint(${routeGeom}, s.geom)::float AS route_fraction,
-            ST_Distance(s.geom::geography, ${routeGeom}::geography)::float AS distance_m
-          FROM stations s
-          JOIN LATERAL (
-            SELECT price, currency, reported_at
-            FROM fuel_prices
-            WHERE station_id = s.id
-              AND fuel_type = $3
-            ORDER BY reported_at DESC NULLS LAST
-            LIMIT 1
-          ) fp ON true
-          WHERE ST_DWithin(
-            s.geom::geography,
-            ${routeGeom}::geography,
-            $2
-          )
-          ORDER BY route_fraction
-          LIMIT ${MAX_RESULTS}
-          `,
-          wkt,
-          corridorMeters,
-          fuel,
-        );
+          : prisma.$queryRawUnsafe<StationRow[]>(
+              `
+              SELECT
+                s.id, s.name, s.brand, s.address, s.city,
+                ST_X(s.geom) AS longitude, ST_Y(s.geom) AS latitude,
+                fp.price::float AS price,
+                COALESCE(fp.currency, 'EUR') AS currency,
+                fp.reported_at,
+                0::float AS route_fraction,
+                0::float AS distance_m
+              FROM stations s
+              JOIN LATERAL (
+                SELECT price, currency, reported_at FROM fuel_prices
+                WHERE station_id = s.id AND fuel_type = $3
+                ORDER BY reported_at DESC NULLS LAST LIMIT 1
+              ) fp ON true
+              WHERE ST_DWithin(s.geom::geography, ${segGeom}::geography, $2)
+              `,
+              segWkt,
+              corridorMeters,
+              fuel,
+            );
+      }),
+    );
+
+    // Deduplicate across segments
+    const stationMap = new Map<string, StationRow>();
+    for (const rows of segmentResults) {
+      for (const row of rows) {
+        if (!stationMap.has(row.id)) stationMap.set(row.id, row);
+      }
+    }
+
+    // Recompute route_fraction and distance_m against the full LineString
+    const uniqueIds = [...stationMap.keys()];
+    if (uniqueIds.length > 0) {
+      const fullGeom = `ST_GeomFromText($1, 4326)`;
+      const placeholders = uniqueIds.map((_, i) => `$${i + 2}`).join(",");
+      const positioned = await prisma.$queryRawUnsafe<{ id: string; route_fraction: number; distance_m: number }[]>(
+        `
+        SELECT
+          s.id,
+          ST_LineLocatePoint(${fullGeom}, s.geom)::float AS route_fraction,
+          ST_Distance(s.geom::geography, ${fullGeom}::geography)::float AS distance_m
+        FROM stations s
+        WHERE s.id IN (${placeholders})
+        `,
+        fullWkt,
+        ...uniqueIds,
+      );
+      for (const p of positioned) {
+        const row = stationMap.get(p.id);
+        if (row) {
+          row.route_fraction = p.route_fraction;
+          row.distance_m = p.distance_m;
+        }
+      }
+    }
+
+    const rows = [...stationMap.values()]
+      .sort((a, b) => a.route_fraction - b.route_fraction)
+      .slice(0, MAX_RESULTS);
 
     const features: StationGeoJSON[] = rows.map((row) => {
       // Estimate detour: round trip off-route, 1.3x road winding factor, 40 km/h avg


### PR DESCRIPTION
## Summary

- PostGIS `ST_DWithin` on geography type silently misses valid matches when the LineString has too many vertices (tested: 2000 points, 670km+ Sangüesa→Murcia route)
- Stations like San Gregorio in Erla (B7 at 1.600€) appeared on the map via bbox query but were missing from the route corridor results — even with 50km corridor width
- Proved by testing: a 100-coord segment of the same route near Erla found both Erla stations, but the full 2000-coord route missed them entirely
- **Fix:** Split long LineStrings (>200 coords) into overlapping segments, query each segment in parallel, deduplicate by station ID, then recompute `route_fraction` and `distance_m` against the full LineString for correct ordering

## Test plan

- [ ] Route Sangüesa → Murcia with B7 fuel: San Gregorio in Erla (1.600€) should now appear in the sidebar station list
- [ ] Short routes (<200 coords) should behave identically to before (single segment, no splitting)
- [ ] Long routes should return same or more stations than before (never fewer)
- [ ] Station ordering in sidebar should be correct (by route_fraction along full route)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Eliminated duplicate station entries in route-stations API responses, providing cleaner and more reliable station lists
* Improved accuracy of distance and position metrics calculated for each station relative to the complete route geometry
* Enhanced query efficiency when handling routes with large or complex geographic features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->