### PR TITLE
fix: show only primary route stations on map to match sidebar

### DIFF
--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -5,7 +5,7 @@ import Map from "react-map-gl/maplibre";
 import type { MapRef, ViewStateChangeEvent } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import type { FuelType, StationsGeoJSONCollection, StationGeoJSON } from "@/types/station";
+import type { FuelType, StationsGeoJSONCollection } from "@/types/station";
 import type { Route } from "./route-layer";
 import { Marker } from "react-map-gl/maplibre";
 import { StationLayer } from "./station-layer";
@@ -73,24 +73,12 @@ export const MapView = forwardRef<MapRef, MapViewProps>(function MapView(
     setLegendRange({ min, max });
   }, []);
 
-  // Merge all route corridor stations (deduplicated) for map display
-  const mergedCorridorStations: StationsGeoJSONCollection = useMemo(() => {
-    if (corridorPerRoute.length === 0) return EMPTY_COLLECTION;
-    const seen = new Set<string>();
-    const features: StationGeoJSON[] = [];
-    for (const collection of corridorPerRoute) {
-      for (const f of collection.features) {
-        if (!seen.has(f.properties.id)) {
-          seen.add(f.properties.id);
-          features.push(f);
-        }
-      }
-    }
-    return { type: "FeatureCollection", features };
-  }, [corridorPerRoute]);
-
-  // Choose which stations to display: corridor when routes active, bbox otherwise
-  const rawDisplayStations = routes ? mergedCorridorStations : bboxStations;
+  // Choose which stations to display: primary route corridor when routes active, bbox otherwise.
+  // Previously this merged all routes' stations, but that caused stations found only by
+  // alternative routes to appear on the map without being in the sidebar station list.
+  const rawDisplayStations = routes
+    ? (corridorPerRoute[primaryRouteIndex] || EMPTY_COLLECTION)
+    : bboxStations;
   // Convert all prices to the user's selected currency
   const displayStations = useConvertedStations(rawDisplayStations);
 


### PR DESCRIPTION
## Summary

- The map showed merged stations from **all** route alternatives, while the sidebar only showed the **primary** route's stations
- This caused stations found by alternative routes (like San Gregorio in Erla) to appear as dots on the map but be missing from the sidebar station list
- **Fix:** Both map and sidebar now use `corridorPerRoute[primaryRouteIndex]` — when you switch routes, both the map dots and the sidebar update together

## Root cause

The Sangüesa → Murcia route has alternatives. One passes through Ejea de los Caballeros (close to Erla, within 5km corridor). The primary (shortest) route goes via the Zaragoza highway (~16.5km from Erla, outside the 5km corridor). The old merged display showed Erla's station on the map from the alternative, but the sidebar correctly showed only the primary route where it's out of corridor range.

## Test plan

- [ ] Route Sangüesa → Murcia: San Gregorio in Erla should NOT appear on the map when the primary (shortest) route is selected (it's 16.5km away, outside 5km corridor)
- [ ] Switch to an alternative route that passes near Erla: station should appear on both map AND sidebar
- [ ] Increase corridor to 20-25km on primary route: Erla should now appear on BOTH map and sidebar
- [ ] Short routes with single alternative: no behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated map rendering to display corridor stations for the primary route instead of aggregating stations from all active routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->