### PR TITLE
fix: Valhalla detour baseline + preserve stations on click

### DIFF
--- a/src/app/api/route-detour/route.ts
+++ b/src/app/api/route-detour/route.ts
@@ -14,7 +14,6 @@ const stationSchema = z.object({
 const bodySchema = z.object({
   stations: z.array(stationSchema).min(1).max(50),
   routeCoordinates: z.array(z.tuple([z.number(), z.number()])).min(2).max(3000),
-  routeDuration: z.number().positive(),
 });
 
 interface DetourResult {
@@ -38,13 +37,13 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { stations, routeCoordinates, routeDuration } = parseResult.data;
+  const { stations, routeCoordinates } = parseResult.data;
   const numCoords = routeCoordinates.length;
 
   try {
     // Pre-compute cumulative segment lengths for consistent length-based fractions.
     // routeFraction from PostGIS (ST_LineLocatePoint) is a fraction of total line
-    // length, so we need length-based — not vertex-index-based — windows and baselines.
+    // length, so we need length-based — not vertex-index-based — exit/rejoin windows.
     const cumLen: number[] = [0];
     for (let i = 1; i < numCoords; i++) {
       const dx = routeCoordinates[i][0] - routeCoordinates[i - 1][0];
@@ -95,26 +94,29 @@ export async function POST(request: NextRequest) {
       const exitCoord = routeCoordinates[exitIdx];
       const rejoinCoord = routeCoordinates[rejoinIdx];
 
-      // Valhalla route: exit → station → rejoin
-      const detourDuration = await getRouteDuration([
-        { lat: exitCoord[1], lon: exitCoord[0] },
-        { lat: s.lat, lon: s.lon },
-        { lat: rejoinCoord[1], lon: rejoinCoord[0] },
+      // Two parallel Valhalla calls: detour leg and direct baseline.
+      // The old linear-interpolation baseline (routeDuration * fraction) assumed
+      // uniform speed, which is wildly wrong on long mixed highway/town routes.
+      const [detourDuration, baselineDuration] = await Promise.all([
+        // exit → station → rejoin
+        getRouteDuration([
+          { lat: exitCoord[1], lon: exitCoord[0] },
+          { lat: s.lat, lon: s.lon },
+          { lat: rejoinCoord[1], lon: rejoinCoord[0] },
+        ]),
+        // exit → rejoin (actual road time for this segment)
+        getRouteDuration([
+          { lat: exitCoord[1], lon: exitCoord[0] },
+          { lat: rejoinCoord[1], lon: rejoinCoord[0] },
+        ]),
       ]);
 
-      if (detourDuration == null) {
+      if (detourDuration == null || baselineDuration == null) {
         return { id: s.id, detourMin: -1 };
       }
 
-      // Baseline: time for the actual exit/rejoin vertices Valhalla routes from
-      // (matches widened window when the distance-based window collapsed)
-      const exitFrac = cumLen[exitIdx] / totalLen;
-      const rejoinFrac = cumLen[rejoinIdx] / totalLen;
-      const originalSegmentDuration =
-        routeDuration * (rejoinFrac - exitFrac);
-
-      // Detour = new leg duration - what you'd normally drive for that segment
-      const detourSec = Math.max(0, detourDuration - originalSegmentDuration);
+      // Detour = via-station time minus direct time for same segment
+      const detourSec = Math.max(0, detourDuration - baselineDuration);
       const detourMin = Math.round(detourSec / 6) / 10; // 1 decimal place
 
       return { id: s.id, detourMin };

--- a/src/app/api/route-detour/route.ts
+++ b/src/app/api/route-detour/route.ts
@@ -70,56 +70,61 @@ export async function POST(request: NextRequest) {
     async function processStation(
       s: z.infer<typeof stationSchema>,
     ): Promise<DetourResult> {
-      if (totalLen === 0) return { id: s.id, detourMin: 0 };
+      try {
+        if (totalLen === 0) return { id: s.id, detourMin: 0 };
 
-      // Symmetric window: 3% of route length each side.
-      const stationDist = s.routeFraction * totalLen;
-      const windowDist = totalLen * 0.03;
-      const exitDist = Math.max(0, stationDist - windowDist);
-      const rejoinDist = Math.min(totalLen, stationDist + windowDist);
+        // Symmetric window: 3% of route length each side.
+        const stationDist = s.routeFraction * totalLen;
+        const windowDist = totalLen * 0.03;
+        const exitDist = Math.max(0, stationDist - windowDist);
+        const rejoinDist = Math.min(totalLen, stationDist + windowDist);
 
-      let exitIdx = distToIndex(exitDist);
-      let rejoinIdx = Math.min(numCoords - 1, distToIndex(rejoinDist));
+        let exitIdx = distToIndex(exitDist);
+        let rejoinIdx = Math.min(numCoords - 1, distToIndex(rejoinDist));
 
-      // If the window collapsed to a single vertex (sparse/downsampled geometry),
-      // widen to guarantee at least two distinct vertices for Valhalla routing.
-      if (exitIdx === rejoinIdx) {
-        exitIdx = Math.max(0, exitIdx - 1);
-        rejoinIdx = Math.min(numCoords - 1, rejoinIdx + 1);
+        // If the window collapsed to a single vertex (sparse/downsampled geometry),
+        // widen to guarantee at least two distinct vertices for Valhalla routing.
         if (exitIdx === rejoinIdx) {
+          exitIdx = Math.max(0, exitIdx - 1);
+          rejoinIdx = Math.min(numCoords - 1, rejoinIdx + 1);
+          if (exitIdx === rejoinIdx) {
+            return { id: s.id, detourMin: -1 };
+          }
+        }
+
+        const exitCoord = routeCoordinates[exitIdx];
+        const rejoinCoord = routeCoordinates[rejoinIdx];
+
+        // Two parallel Valhalla calls: detour leg and direct baseline.
+        // The old linear-interpolation baseline (routeDuration * fraction) assumed
+        // uniform speed, which is wildly wrong on long mixed highway/town routes.
+        const [detourDuration, baselineDuration] = await Promise.all([
+          // exit → station → rejoin
+          getRouteDuration([
+            { lat: exitCoord[1], lon: exitCoord[0] },
+            { lat: s.lat, lon: s.lon },
+            { lat: rejoinCoord[1], lon: rejoinCoord[0] },
+          ]),
+          // exit → rejoin (actual road time for this segment)
+          getRouteDuration([
+            { lat: exitCoord[1], lon: exitCoord[0] },
+            { lat: rejoinCoord[1], lon: rejoinCoord[0] },
+          ]),
+        ]);
+
+        if (detourDuration == null || baselineDuration == null) {
           return { id: s.id, detourMin: -1 };
         }
-      }
 
-      const exitCoord = routeCoordinates[exitIdx];
-      const rejoinCoord = routeCoordinates[rejoinIdx];
+        // Detour = via-station time minus direct time for same segment
+        const detourSec = Math.max(0, detourDuration - baselineDuration);
+        const detourMin = Math.round(detourSec / 6) / 10; // 1 decimal place
 
-      // Two parallel Valhalla calls: detour leg and direct baseline.
-      // The old linear-interpolation baseline (routeDuration * fraction) assumed
-      // uniform speed, which is wildly wrong on long mixed highway/town routes.
-      const [detourDuration, baselineDuration] = await Promise.all([
-        // exit → station → rejoin
-        getRouteDuration([
-          { lat: exitCoord[1], lon: exitCoord[0] },
-          { lat: s.lat, lon: s.lon },
-          { lat: rejoinCoord[1], lon: rejoinCoord[0] },
-        ]),
-        // exit → rejoin (actual road time for this segment)
-        getRouteDuration([
-          { lat: exitCoord[1], lon: exitCoord[0] },
-          { lat: rejoinCoord[1], lon: rejoinCoord[0] },
-        ]),
-      ]);
-
-      if (detourDuration == null || baselineDuration == null) {
+        return { id: s.id, detourMin };
+      } catch (err) {
+        console.warn(`[route-detour] station ${s.id} failed:`, err);
         return { id: s.id, detourMin: -1 };
       }
-
-      // Detour = via-station time minus direct time for same segment
-      const detourSec = Math.max(0, detourDuration - baselineDuration);
-      const detourMin = Math.round(detourSec / 6) / 10; // 1 decimal place
-
-      return { id: s.id, detourMin };
     }
 
     // Run with concurrency limit

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -208,6 +208,16 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
     setSelectedStationId(null);
   }, []);
 
+  const handleSelectStation = useCallback((id: string | null) => {
+    setSelectedStationId(id);
+    // Deselect clears station-leg preview — search-panel's effect handles waypoint cleanup
+    if (id == null) setStationLegRoutes(null);
+  }, []);
+
+  const handleClearStationLeg = useCallback(() => {
+    setStationLegRoutes(null);
+  }, []);
+
   const handleFlyTo = useCallback((coords: [number, number], stationId?: string) => {
     mapRef.current?.flyTo({ center: coords, zoom: 14, duration: 1500 });
     if (stationId) setSelectedStationId(stationId);
@@ -341,7 +351,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           displayRoutes={stationLegRoutes ?? routeState?.routes ?? null}
           primaryRouteIndex={routeState?.primaryIndex ?? 0}
           selectedStationId={selectedStationId}
-          onSelectStation={setSelectedStationId}
+          onSelectStation={handleSelectStation}
           maxPrice={maxPrice}
           onMaxPriceChange={setMaxPrice}
           maxDetour={maxDetour}
@@ -359,7 +369,9 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           onFlyTo={handleFlyTo}
           onRoute={handleRoute}
           onClearRoute={handleClearRoute}
+          onClearStationLeg={handleClearStationLeg}
           onSelectRoute={handleSelectRoute}
+          selectedStationId={selectedStationId}
           routeError={routeError}
           routes={routeState?.routes ?? null}
           primaryRouteIndex={routeState?.primaryIndex ?? 0}

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -41,6 +41,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   const mapRef = useRef<MapRef | null>(null);
 
   const routeAbortRef = useRef<AbortController | null>(null);
+  const stationLegAbortRef = useRef<AbortController | null>(null);
   const [mapCenter, setMapCenter] = useState<[number, number]>(center);
   const [selectedStationId, setSelectedStationId] = useState<string | null>(null);
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
@@ -105,11 +106,19 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
 
   const handleRoute = useCallback(
     async (origin: [number, number], destination: [number, number], waypoints?: [number, number][], options?: { isStationLeg?: boolean }) => {
-      if (routeAbortRef.current) routeAbortRef.current.abort();
-      const controller = new AbortController();
-      routeAbortRef.current = controller;
-
       const isStationLeg = options?.isStationLeg ?? false;
+      // Use separate abort refs so clearing a station-leg doesn't cancel a normal route and vice versa
+      const abortRef = isStationLeg ? stationLegAbortRef : routeAbortRef;
+      if (abortRef.current) abortRef.current.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      // A normal route supersedes any pending station-leg preview
+      if (!isStationLeg && stationLegAbortRef.current) {
+        stationLegAbortRef.current.abort();
+        stationLegAbortRef.current = null;
+      }
+
       setIsRouteLoading(true);
       setRouteError(null);
       try {
@@ -120,7 +129,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           signal: controller.signal,
         });
         if (!res.ok) {
-          if (routeAbortRef.current === controller) {
+          if (abortRef.current === controller) {
             if (!isStationLeg) setRouteState(null);
             setStationLegRoutes(null);
             setRouteError("route.error");
@@ -129,7 +138,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
         }
         const data: { routes: Route[] } = await res.json();
         if (data.routes.length === 0) {
-          if (routeAbortRef.current === controller) {
+          if (abortRef.current === controller) {
             if (!isStationLeg) setRouteState(null);
             setStationLegRoutes(null);
             setRouteError("route.noRoute");
@@ -137,7 +146,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           return;
         }
         // Only write state if this is still the active request
-        if (routeAbortRef.current !== controller) return;
+        if (abortRef.current !== controller) return;
 
         if (isStationLeg) {
           // Station-leg: only update the display route, keep base routes
@@ -163,7 +172,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error("Route calculation failed:", err);
-        if (routeAbortRef.current === controller) {
+        if (abortRef.current === controller) {
           if (!isStationLeg) setRouteState(null);
           setStationLegRoutes(null);
           setRouteError("route.error");
@@ -200,6 +209,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
 
   const handleClearRoute = useCallback(() => {
     if (routeAbortRef.current) routeAbortRef.current.abort();
+    if (stationLegAbortRef.current) stationLegAbortRef.current.abort();
     setRouteState(null);
     setStationLegRoutes(null);
     setIsRouteLoading(false);
@@ -211,10 +221,14 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   const handleSelectStation = useCallback((id: string | null) => {
     setSelectedStationId(id);
     // Deselect clears station-leg preview — search-panel's effect handles waypoint cleanup
-    if (id == null) setStationLegRoutes(null);
+    if (id == null) {
+      if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
+      setStationLegRoutes(null);
+    }
   }, []);
 
   const handleClearStationLeg = useCallback(() => {
+    if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
     setStationLegRoutes(null);
   }, []);
 

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -32,6 +32,10 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   const [selectedFuel, setSelectedFuel] = useState<FuelType>(defaultFuel as FuelType);
   const [corridorKm, setCorridorKm] = useState(5);
   const [routeState, setRouteState] = useState<RouteState | null>(null);
+  // Station-leg routes: when a user clicks a station, we recalculate the route
+  // through that station but DON'T re-fetch corridor stations. The base routes
+  // in routeState still control corridor fetching.
+  const [stationLegRoutes, setStationLegRoutes] = useState<Route[] | null>(null);
   const [isRouteLoading, setIsRouteLoading] = useState(false);
   const [primaryStations, setPrimaryStations] = useState<StationsGeoJSONCollection>({ type: "FeatureCollection", features: [] });
   const mapRef = useRef<MapRef | null>(null);
@@ -100,11 +104,12 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   }, []);
 
   const handleRoute = useCallback(
-    async (origin: [number, number], destination: [number, number], waypoints?: [number, number][]) => {
+    async (origin: [number, number], destination: [number, number], waypoints?: [number, number][], options?: { isStationLeg?: boolean }) => {
       if (routeAbortRef.current) routeAbortRef.current.abort();
       const controller = new AbortController();
       routeAbortRef.current = controller;
 
+      const isStationLeg = options?.isStationLeg ?? false;
       setIsRouteLoading(true);
       setRouteError(null);
       try {
@@ -116,7 +121,8 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
         });
         if (!res.ok) {
           if (routeAbortRef.current === controller) {
-            setRouteState(null);
+            if (!isStationLeg) setRouteState(null);
+            setStationLegRoutes(null);
             setRouteError("route.error");
           }
           return;
@@ -124,7 +130,8 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
         const data: { routes: Route[] } = await res.json();
         if (data.routes.length === 0) {
           if (routeAbortRef.current === controller) {
-            setRouteState(null);
+            if (!isStationLeg) setRouteState(null);
+            setStationLegRoutes(null);
             setRouteError("route.noRoute");
           }
           return;
@@ -132,10 +139,18 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
         // Only write state if this is still the active request
         if (routeAbortRef.current !== controller) return;
 
-        setRouteState({ routes: data.routes, primaryIndex: 0 });
-        // Clear stale corridor data so the detour effect doesn't pair
-        // the new route geometry with the previous corridor's stations
-        setPrimaryStations({ type: "FeatureCollection", features: [] });
+        if (isStationLeg) {
+          // Station-leg: only update the display route, keep base routes
+          // and corridor stations untouched
+          setStationLegRoutes(data.routes);
+        } else {
+          // Normal route: update base routes and trigger corridor fetch
+          setRouteState({ routes: data.routes, primaryIndex: 0 });
+          setStationLegRoutes(null);
+          // Clear stale corridor data so the detour effect doesn't pair
+          // the new route geometry with the previous corridor's stations
+          setPrimaryStations({ type: "FeatureCollection", features: [] });
+        }
 
         const primary = data.routes[0];
         mapRef.current?.fitBounds(
@@ -149,7 +164,8 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error("Route calculation failed:", err);
         if (routeAbortRef.current === controller) {
-          setRouteState(null);
+          if (!isStationLeg) setRouteState(null);
+          setStationLegRoutes(null);
           setRouteError("route.error");
         }
       } finally {
@@ -161,6 +177,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
 
   const handleSelectRoute = useCallback((index: number) => {
     setSelectedStationId(null);
+    setStationLegRoutes(null);
     // Clear stale corridor so detour effect doesn't pair new primary route
     // with previous route's stations while MapView lifts the update
     setPrimaryStations({ type: "FeatureCollection", features: [] });
@@ -184,6 +201,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   const handleClearRoute = useCallback(() => {
     if (routeAbortRef.current) routeAbortRef.current.abort();
     setRouteState(null);
+    setStationLegRoutes(null);
     setIsRouteLoading(false);
     setRouteError(null);
     setPrimaryStations({ type: "FeatureCollection", features: [] });
@@ -231,7 +249,6 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
 
     (async () => {
       const coords = route.geometry.coordinates as [number, number][];
-      const duration = route.duration;
 
       // Process in batches, sorted by routeFraction (first-visible first)
       for (let i = 0; i < eligible.length; i += DETOUR_BATCH_SIZE) {
@@ -250,7 +267,6 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
                 routeFraction: f.properties.routeFraction,
               })),
               routeCoordinates: coords,
-              routeDuration: duration,
             }),
             signal: controller.signal,
           });
@@ -322,6 +338,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           clusterStations={clusterStations}
           corridorKm={corridorKm}
           routes={routeState?.routes ?? null}
+          displayRoutes={stationLegRoutes ?? routeState?.routes ?? null}
           primaryRouteIndex={routeState?.primaryIndex ?? 0}
           selectedStationId={selectedStationId}
           onSelectStation={setSelectedStationId}

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -188,6 +188,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
 
   const handleSelectRoute = useCallback((index: number) => {
     setSelectedStationId(null);
+    if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
     setStationLegRoutes(null);
     // Clear stale corridor so detour effect doesn't pair new primary route
     // with previous route's stations while MapView lifts the update

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -224,12 +224,14 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
     if (id == null) {
       if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
       setStationLegRoutes(null);
+      setIsRouteLoading(false);
     }
   }, []);
 
   const handleClearStationLeg = useCallback(() => {
     if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
     setStationLegRoutes(null);
+    setIsRouteLoading(false);
   }, []);
 
   const handleFlyTo = useCallback((coords: [number, number], stationId?: string) => {

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -178,6 +178,8 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           setRouteError("route.error");
         }
       } finally {
+        // Null out the ref so clear handlers know no request is in flight
+        if (abortRef.current === controller) abortRef.current = null;
         if (!controller.signal.aborted) setIsRouteLoading(false);
       }
     },

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -224,14 +224,15 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
     if (id == null) {
       if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
       setStationLegRoutes(null);
-      setIsRouteLoading(false);
+      // Only clear loading if no normal route request is in flight
+      if (!routeAbortRef.current) setIsRouteLoading(false);
     }
   }, []);
 
   const handleClearStationLeg = useCallback(() => {
     if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
     setStationLegRoutes(null);
-    setIsRouteLoading(false);
+    if (!routeAbortRef.current) setIsRouteLoading(false);
   }, []);
 
   const handleFlyTo = useCallback((coords: [number, number], stationId?: string) => {

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -28,6 +28,8 @@ interface MapViewProps {
   clusterStations: boolean;
   corridorKm: number;
   routes: Route[] | null;
+  /** Routes to render on the map (may differ from `routes` during station-leg preview). */
+  displayRoutes?: Route[] | null;
   primaryRouteIndex: number;
   selectedStationId?: string | null;
   onSelectStation?: (id: string | null) => void;
@@ -45,7 +47,7 @@ interface MapViewProps {
 }
 
 export const MapView = forwardRef<MapRef, MapViewProps>(function MapView(
-  { selectedFuel, center, zoom, clusterStations, corridorKm, routes, primaryRouteIndex, selectedStationId, onSelectStation, maxPrice, onMaxPriceChange, maxDetour, onMapMove, onSelectRoute, onPrimaryStationsChange, onStationsLoadingChange, onStationsErrorChange, detourMap, userLocation, onMapReady },
+  { selectedFuel, center, zoom, clusterStations, corridorKm, routes, displayRoutes, primaryRouteIndex, selectedStationId, onSelectStation, maxPrice, onMaxPriceChange, maxDetour, onMapMove, onSelectRoute, onPrimaryStationsChange, onStationsLoadingChange, onStationsErrorChange, detourMap, userLocation, onMapReady },
   ref,
 ) {
   const { mapStyle } = useTheme();
@@ -319,11 +321,11 @@ export const MapView = forwardRef<MapRef, MapViewProps>(function MapView(
       style={{ width: "100%", height: "100%" }}
     >
       {showCountryMarkers && <CountryMarkers />}
-      {routes && routes.length > 0 && (
+      {(displayRoutes ?? routes) && (displayRoutes ?? routes)!.length > 0 && (
         <RouteLayer
-          routes={routes}
-          primaryIndex={primaryRouteIndex}
-          onSelectRoute={onSelectRoute}
+          routes={(displayRoutes ?? routes)!}
+          primaryIndex={displayRoutes ? 0 : primaryRouteIndex}
+          onSelectRoute={displayRoutes ? undefined : onSelectRoute}
           beforeLayerId={stationBeforeId}
         />
       )}

--- a/src/components/search/search-panel.tsx
+++ b/src/components/search/search-panel.tsx
@@ -18,7 +18,9 @@ interface SearchPanelProps {
   onFlyTo: (coords: [number, number], stationId?: string) => void;
   onRoute: (origin: [number, number], destination: [number, number], waypoints?: [number, number][], options?: { isStationLeg?: boolean }) => void;
   onClearRoute: () => void;
+  onClearStationLeg?: () => void;
   onSelectRoute?: (index: number) => void;
+  selectedStationId?: string | null;
   routeError?: string | null;
   routes: Route[] | null;
   primaryRouteIndex: number;
@@ -53,7 +55,9 @@ export function SearchPanel({
   onFlyTo,
   onRoute,
   onClearRoute,
+  onClearStationLeg,
   onSelectRoute,
+  selectedStationId,
   routeError,
   routes,
   primaryRouteIndex,
@@ -89,6 +93,17 @@ export function SearchPanel({
       setPhase("destination");
     }
   }, [routeError, phase, routes]);
+
+  // When the selected station is cleared, remove station-leg waypoint and preview route
+  useEffect(() => {
+    if (selectedStationId != null) return;
+    setWaypoints((prev) => {
+      if (!prev.some((wp) => wp.isStationLeg)) return prev;
+      return prev.filter((wp) => !wp.isStationLeg);
+    });
+    onClearStationLeg?.();
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- onClearStationLeg is a stable callback
+  }, [selectedStationId]);
 
   const primaryRoute = routes?.[primaryRouteIndex] ?? null;
 
@@ -313,10 +328,16 @@ export function SearchPanel({
   // Remove waypoint
   const removeWaypoint = useCallback(
     (wpId: number) => {
-      setWaypoints((prev) => prev.filter((wp) => wp.id !== wpId));
-      setWpRouteVersion((v) => v + 1);
+      const wp = waypoints.find((w) => w.id === wpId);
+      setWaypoints((prev) => prev.filter((w) => w.id !== wpId));
+      if (wp?.isStationLeg) {
+        // Station-leg removal: just clear the preview route, no recalculation
+        onClearStationLeg?.();
+      } else {
+        setWpRouteVersion((v) => v + 1);
+      }
     },
-    [],
+    [waypoints, onClearStationLeg],
   );
 
   // Transient message for station-leg feedback

--- a/src/components/search/search-panel.tsx
+++ b/src/components/search/search-panel.tsx
@@ -16,7 +16,7 @@ const MAX_WAYPOINTS = 5;
 interface SearchPanelProps {
   mapCenter: [number, number];
   onFlyTo: (coords: [number, number], stationId?: string) => void;
-  onRoute: (origin: [number, number], destination: [number, number], waypoints?: [number, number][]) => void;
+  onRoute: (origin: [number, number], destination: [number, number], waypoints?: [number, number][], options?: { isStationLeg?: boolean }) => void;
   onClearRoute: () => void;
   onSelectRoute?: (index: number) => void;
   routeError?: string | null;
@@ -123,11 +123,11 @@ export function SearchPanel({
 
   // Calculate route with current state
   const calculateRoute = useCallback(
-    (o: Location, d: Location, wps: WaypointEntry[]) => {
+    (o: Location, d: Location, wps: WaypointEntry[], options?: { isStationLeg?: boolean }) => {
       const wpCoords = wps
         .filter((wp) => wp.location != null)
         .map((wp) => wp.location!.coordinates);
-      onRoute(o.coordinates, d.coordinates, wpCoords.length > 0 ? wpCoords : undefined);
+      onRoute(o.coordinates, d.coordinates, wpCoords.length > 0 ? wpCoords : undefined, options);
     },
     [onRoute],
   );
@@ -171,12 +171,16 @@ export function SearchPanel({
   // Track whether waypoints changed in a way that requires route recalculation.
   // Bumped by handlers that modify resolved waypoints (select, remove, station leg).
   const [wpRouteVersion, setWpRouteVersion] = useState(0);
+  // Separate flag: true when the latest bump was a station-leg change
+  const stationLegBumpRef = useRef(false);
 
   useEffect(() => {
     if (wpRouteVersion === 0) return; // skip initial mount
     if (origin && destination) {
       if (phase !== "route") setPhase("route");
-      calculateRoute(origin, destination, waypoints);
+      const isStationLeg = stationLegBumpRef.current;
+      stationLegBumpRef.current = false;
+      calculateRoute(origin, destination, waypoints, isStationLeg ? { isStationLeg: true } : undefined);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wpRouteVersion]);
@@ -361,6 +365,7 @@ export function SearchPanel({
 
         return [...withoutOld.slice(0, insertIdx), entry, ...withoutOld.slice(insertIdx)];
       });
+      stationLegBumpRef.current = true;
       setWpRouteVersion((v) => v + 1);
     },
     [origin, destination, phase, waypoints, primaryRoute, t],


### PR DESCRIPTION
## Summary
- **Detour baseline**: Replaced linear-interpolation baseline (`routeDuration * fraction`) with a parallel Valhalla `exit → rejoin` route call. The old approach assumed uniform speed along the entire route, producing wildly inaccurate detour estimates on mixed highway/town routes (e.g. +39min displayed instead of the real +12min for Erla on Sangüesa→Murcia).
- **Station-leg click**: Clicking a station now recalculates the route through it for **display only** — corridor stations are NOT re-fetched. A new `stationLegRoutes` state in home-client stores the display-only route, while the base `routeState` still controls corridor fetching. MapView receives a new `displayRoutes` prop used exclusively for route-layer rendering.

## Test plan
- [ ] Calculate Sangüesa → Murcia route, verify Erla detour shows ~12min (not 39)
- [ ] Click a station in the list — route line updates to go through it, station list stays unchanged
- [ ] Click another station — route updates again, station list still unchanged
- [ ] Remove station-leg waypoint — route returns to original
- [ ] Change origin/destination — full recalculation (route + stations) still works
- [ ] Verify detour values are reasonable across different route lengths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map and search support independent station-leg previews: select/clear stations to show or abort preview routes without replacing the primary route; preview lifecycle is isolated from main route requests.

* **Bug Fixes**
  * Detour calculations now compute and validate a baseline route via a separate routing call, run checks concurrently, and return a safe fallback for invalid or failed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->