### PR TITLE
feat: stream detour results per-station via NDJSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pumperly",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pumperly",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@prisma/adapter-pg": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pumperly",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Open-source energy route planner for fuel and electric vehicles. Self-hostable.",
   "private": true,
   "scripts": {

--- a/src/app/api/route-detour/route.ts
+++ b/src/app/api/route-detour/route.ts
@@ -12,7 +12,7 @@ const stationSchema = z.object({
 });
 
 const bodySchema = z.object({
-  stations: z.array(stationSchema).min(1).max(50),
+  stations: z.array(stationSchema).min(1),
   routeCoordinates: z.array(z.tuple([z.number(), z.number()])).min(2).max(3000),
 });
 

--- a/src/app/api/route-detour/route.ts
+++ b/src/app/api/route-detour/route.ts
@@ -6,14 +6,19 @@ const CONCURRENCY = 8;
 
 const stationSchema = z.object({
   id: z.string(),
-  lon: z.number(),
-  lat: z.number(),
-  routeFraction: z.number(),
+  lon: z.number().min(-180).max(180),
+  lat: z.number().min(-90).max(90),
+  routeFraction: z.number().min(0).max(1),
 });
 
+const coordSchema = z.tuple([
+  z.number().min(-180).max(180),
+  z.number().min(-90).max(90),
+]);
+
 const bodySchema = z.object({
-  stations: z.array(stationSchema).min(1),
-  routeCoordinates: z.array(z.tuple([z.number(), z.number()])).min(2).max(3000),
+  stations: z.array(stationSchema).min(1).max(500),
+  routeCoordinates: z.array(coordSchema).min(2).max(3000),
 });
 
 export async function POST(request: NextRequest) {
@@ -110,9 +115,13 @@ export async function POST(request: NextRequest) {
 
   const encoder = new TextEncoder();
   const queue = [...stations];
+  const { signal } = request;
 
   const stream = new ReadableStream({
     async start(controller) {
+      // Drain queue on client disconnect so workers stop picking up new stations
+      const onAbort = () => { queue.length = 0; };
+      signal.addEventListener("abort", onAbort);
       try {
         const workers: Promise<void>[] = [];
         for (let i = 0; i < CONCURRENCY; i++) {
@@ -121,6 +130,7 @@ export async function POST(request: NextRequest) {
               while (queue.length > 0) {
                 const station = queue.shift()!;
                 const result = await processStation(station);
+                if (signal.aborted) return;
                 controller.enqueue(encoder.encode(JSON.stringify(result) + "\n"));
               }
             })(),
@@ -130,6 +140,7 @@ export async function POST(request: NextRequest) {
       } catch (err) {
         console.error("[route-detour] stream failed:", err);
       } finally {
+        signal.removeEventListener("abort", onAbort);
         controller.close();
       }
     },

--- a/src/app/api/route-detour/route.ts
+++ b/src/app/api/route-detour/route.ts
@@ -4,6 +4,11 @@ import { getRouteDuration } from "@/lib/valhalla";
 
 const CONCURRENCY = 8;
 
+const detourResultSchema = z.object({
+  id: z.string(),
+  detourMin: z.number(),
+});
+
 const stationSchema = z.object({
   id: z.string(),
   lon: z.number().min(-180).max(180),
@@ -21,6 +26,7 @@ const bodySchema = z.object({
   routeCoordinates: z.array(coordSchema).min(2).max(3000),
 });
 
+/** Stream per-station detour times as NDJSON. Each line: `{"id":"…","detourMin":…}` */
 export async function POST(request: NextRequest) {
   let body: unknown;
   try {
@@ -92,11 +98,11 @@ export async function POST(request: NextRequest) {
           { lat: exitCoord[1], lon: exitCoord[0] },
           { lat: s.lat, lon: s.lon },
           { lat: rejoinCoord[1], lon: rejoinCoord[0] },
-        ]),
+        ], "auto", signal),
         getRouteDuration([
           { lat: exitCoord[1], lon: exitCoord[0] },
           { lat: rejoinCoord[1], lon: rejoinCoord[0] },
-        ]),
+        ], "auto", signal),
       ]);
 
       if (detourDuration == null || baselineDuration == null) {
@@ -129,7 +135,7 @@ export async function POST(request: NextRequest) {
             (async () => {
               while (queue.length > 0) {
                 const station = queue.shift()!;
-                const result = await processStation(station);
+                const result = detourResultSchema.parse(await processStation(station));
                 if (signal.aborted) return;
                 controller.enqueue(encoder.encode(JSON.stringify(result) + "\n"));
               }

--- a/src/app/api/route-detour/route.ts
+++ b/src/app/api/route-detour/route.ts
@@ -16,11 +16,6 @@ const bodySchema = z.object({
   routeCoordinates: z.array(z.tuple([z.number(), z.number()])).min(2).max(3000),
 });
 
-interface DetourResult {
-  id: string;
-  detourMin: number;
-}
-
 export async function POST(request: NextRequest) {
   let body: unknown;
   try {
@@ -40,114 +35,111 @@ export async function POST(request: NextRequest) {
   const { stations, routeCoordinates } = parseResult.data;
   const numCoords = routeCoordinates.length;
 
-  try {
-    // Pre-compute cumulative segment lengths for consistent length-based fractions.
-    // routeFraction from PostGIS (ST_LineLocatePoint) is a fraction of total line
-    // length, so we need length-based — not vertex-index-based — exit/rejoin windows.
-    const cumLen: number[] = [0];
-    for (let i = 1; i < numCoords; i++) {
-      const dx = routeCoordinates[i][0] - routeCoordinates[i - 1][0];
-      const dy = routeCoordinates[i][1] - routeCoordinates[i - 1][1];
-      cumLen.push(cumLen[i - 1] + Math.sqrt(dx * dx + dy * dy));
+  // Pre-compute cumulative segment lengths for consistent length-based fractions.
+  // routeFraction from PostGIS (ST_LineLocatePoint) is a fraction of total line
+  // length, so we need length-based — not vertex-index-based — exit/rejoin windows.
+  const cumLen: number[] = [0];
+  for (let i = 1; i < numCoords; i++) {
+    const dx = routeCoordinates[i][0] - routeCoordinates[i - 1][0];
+    const dy = routeCoordinates[i][1] - routeCoordinates[i - 1][1];
+    cumLen.push(cumLen[i - 1] + Math.sqrt(dx * dx + dy * dy));
+  }
+  const totalLen = cumLen[numCoords - 1];
+
+  // Binary-search: find the vertex index where cumLen >= targetLen
+  function distToIndex(targetLen: number): number {
+    let lo = 0, hi = numCoords - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (cumLen[mid] < targetLen) lo = mid + 1;
+      else hi = mid;
     }
-    const totalLen = cumLen[numCoords - 1];
+    return lo;
+  }
 
-    // Binary-search: find the vertex index where cumLen >= targetLen
-    function distToIndex(targetLen: number): number {
-      let lo = 0, hi = numCoords - 1;
-      while (lo < hi) {
-        const mid = (lo + hi) >> 1;
-        if (cumLen[mid] < targetLen) lo = mid + 1;
-        else hi = mid;
-      }
-      return lo;
-    }
+  async function processStation(
+    s: z.infer<typeof stationSchema>,
+  ): Promise<{ id: string; detourMin: number }> {
+    try {
+      if (totalLen === 0) return { id: s.id, detourMin: 0 };
 
-    // Process stations with controlled concurrency
-    const results: DetourResult[] = [];
-    const queue = [...stations];
+      const stationDist = s.routeFraction * totalLen;
+      const windowDist = totalLen * 0.03;
+      const exitDist = Math.max(0, stationDist - windowDist);
+      const rejoinDist = Math.min(totalLen, stationDist + windowDist);
 
-    async function processStation(
-      s: z.infer<typeof stationSchema>,
-    ): Promise<DetourResult> {
-      try {
-        if (totalLen === 0) return { id: s.id, detourMin: 0 };
+      let exitIdx = distToIndex(exitDist);
+      let rejoinIdx = Math.min(numCoords - 1, distToIndex(rejoinDist));
 
-        // Symmetric window: 3% of route length each side.
-        const stationDist = s.routeFraction * totalLen;
-        const windowDist = totalLen * 0.03;
-        const exitDist = Math.max(0, stationDist - windowDist);
-        const rejoinDist = Math.min(totalLen, stationDist + windowDist);
-
-        let exitIdx = distToIndex(exitDist);
-        let rejoinIdx = Math.min(numCoords - 1, distToIndex(rejoinDist));
-
-        // If the window collapsed to a single vertex (sparse/downsampled geometry),
-        // widen to guarantee at least two distinct vertices for Valhalla routing.
+      if (exitIdx === rejoinIdx) {
+        exitIdx = Math.max(0, exitIdx - 1);
+        rejoinIdx = Math.min(numCoords - 1, rejoinIdx + 1);
         if (exitIdx === rejoinIdx) {
-          exitIdx = Math.max(0, exitIdx - 1);
-          rejoinIdx = Math.min(numCoords - 1, rejoinIdx + 1);
-          if (exitIdx === rejoinIdx) {
-            return { id: s.id, detourMin: -1 };
-          }
-        }
-
-        const exitCoord = routeCoordinates[exitIdx];
-        const rejoinCoord = routeCoordinates[rejoinIdx];
-
-        // Two parallel Valhalla calls: detour leg and direct baseline.
-        // The old linear-interpolation baseline (routeDuration * fraction) assumed
-        // uniform speed, which is wildly wrong on long mixed highway/town routes.
-        const [detourDuration, baselineDuration] = await Promise.all([
-          // exit → station → rejoin
-          getRouteDuration([
-            { lat: exitCoord[1], lon: exitCoord[0] },
-            { lat: s.lat, lon: s.lon },
-            { lat: rejoinCoord[1], lon: rejoinCoord[0] },
-          ]),
-          // exit → rejoin (actual road time for this segment)
-          getRouteDuration([
-            { lat: exitCoord[1], lon: exitCoord[0] },
-            { lat: rejoinCoord[1], lon: rejoinCoord[0] },
-          ]),
-        ]);
-
-        if (detourDuration == null || baselineDuration == null) {
           return { id: s.id, detourMin: -1 };
         }
+      }
 
-        // Detour = via-station time minus direct time for same segment
-        const detourSec = Math.max(0, detourDuration - baselineDuration);
-        const detourMin = Math.round(detourSec / 6) / 10; // 1 decimal place
+      const exitCoord = routeCoordinates[exitIdx];
+      const rejoinCoord = routeCoordinates[rejoinIdx];
 
-        return { id: s.id, detourMin };
-      } catch (err) {
-        console.warn(`[route-detour] station ${s.id} failed:`, err);
+      const [detourDuration, baselineDuration] = await Promise.all([
+        getRouteDuration([
+          { lat: exitCoord[1], lon: exitCoord[0] },
+          { lat: s.lat, lon: s.lon },
+          { lat: rejoinCoord[1], lon: rejoinCoord[0] },
+        ]),
+        getRouteDuration([
+          { lat: exitCoord[1], lon: exitCoord[0] },
+          { lat: rejoinCoord[1], lon: rejoinCoord[0] },
+        ]),
+      ]);
+
+      if (detourDuration == null || baselineDuration == null) {
         return { id: s.id, detourMin: -1 };
       }
-    }
 
-    // Run with concurrency limit
-    const workers: Promise<void>[] = [];
-    for (let i = 0; i < CONCURRENCY; i++) {
-      workers.push(
-        (async () => {
-          while (queue.length > 0) {
-            const station = queue.shift()!;
-            const result = await processStation(station);
-            results.push(result);
-          }
-        })(),
-      );
-    }
-    await Promise.all(workers);
+      const detourSec = Math.max(0, detourDuration - baselineDuration);
+      const detourMin = Math.round(detourSec / 6) / 10;
 
-    return NextResponse.json({ detours: results });
-  } catch (err) {
-    console.error("[route-detour] failed:", err);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+      return { id: s.id, detourMin };
+    } catch (err) {
+      console.warn(`[route-detour] station ${s.id} failed:`, err);
+      return { id: s.id, detourMin: -1 };
+    }
   }
+
+  const encoder = new TextEncoder();
+  const queue = [...stations];
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      try {
+        const workers: Promise<void>[] = [];
+        for (let i = 0; i < CONCURRENCY; i++) {
+          workers.push(
+            (async () => {
+              while (queue.length > 0) {
+                const station = queue.shift()!;
+                const result = await processStation(station);
+                controller.enqueue(encoder.encode(JSON.stringify(result) + "\n"));
+              }
+            })(),
+          );
+        }
+        await Promise.all(workers);
+      } catch (err) {
+        console.error("[route-detour] stream failed:", err);
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "application/x-ndjson",
+      "Transfer-Encoding": "chunked",
+      "Cache-Control": "no-cache",
+    },
+  });
 }

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -11,7 +11,9 @@ import { Navbar } from "@/components/nav/navbar";
 import { MapView } from "@/components/map/map-view";
 import { SearchPanel } from "@/components/search/search-panel";
 
-const DETOUR_BATCH_SIZE = 15;
+// Debounce interval (ms) for batching per-station stream updates into
+// a single React state update, avoiding excessive re-renders.
+const DETOUR_FLUSH_MS = 150;
 
 interface Props {
   defaultFuel: string;
@@ -247,13 +249,12 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
     setPrimaryStations(stations);
   }, []);
 
-  // Progressive Valhalla-based detour calculation
+  // Streaming Valhalla-based detour calculation — results appear per-station
   const detourAbortRef = useRef<AbortController | null>(null);
   const [detourMap, setDetourMap] = useState<Record<string, number>>({});
   const [detoursLoading, setDetoursLoading] = useState(false);
 
   useEffect(() => {
-    // Abort any previous detour fetch
     if (detourAbortRef.current) detourAbortRef.current.abort();
     setDetourMap({});
 
@@ -263,7 +264,6 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
       return;
     }
 
-    // All stations with routeFraction (price may be null for EV chargers)
     const eligible = primaryStations.features
       .filter((f) => f.properties.routeFraction != null)
       .sort((a, b) => (a.properties.routeFraction ?? 0) - (b.properties.routeFraction ?? 0));
@@ -280,54 +280,74 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
     (async () => {
       const coords = route.geometry.coordinates as [number, number][];
 
-      // Process in batches, sorted by routeFraction (first-visible first)
-      for (let i = 0; i < eligible.length; i += DETOUR_BATCH_SIZE) {
-        if (controller.signal.aborted) return;
+      try {
+        const res = await fetch("/api/route-detour", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            stations: eligible.map((f) => ({
+              id: f.properties.id,
+              lon: f.geometry.coordinates[0],
+              lat: f.geometry.coordinates[1],
+              routeFraction: f.properties.routeFraction,
+            })),
+            routeCoordinates: coords,
+          }),
+          signal: controller.signal,
+        });
 
-        const batch = eligible.slice(i, i + DETOUR_BATCH_SIZE);
-        try {
-          const res = await fetch("/api/route-detour", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              stations: batch.map((f) => ({
-                id: f.properties.id,
-                lon: f.geometry.coordinates[0],
-                lat: f.geometry.coordinates[1],
-                routeFraction: f.properties.routeFraction,
-              })),
-              routeCoordinates: coords,
-            }),
-            signal: controller.signal,
-          });
-          if (!res.ok) {
-            // Mark all stations in this batch as failed so they don't
-            // pass the detour filter as if they were still loading
-            setDetourMap((prev) => {
-              const next = { ...prev };
-              for (const f of batch) next[f.properties.id] = -1;
-              return next;
-            });
-            continue;
-          }
-          const data: { detours: { id: string; detourMin: number }[] } = await res.json();
-          if (controller.signal.aborted) return;
-
-          setDetourMap((prev) => {
-            const next = { ...prev };
-            for (const d of data.detours) next[d.id] = d.detourMin;
-            return next;
-          });
-        } catch (err) {
-          if (err instanceof DOMException && err.name === "AbortError") return;
-          // Network/parse failures: mark batch as failed so stations
-          // don't pass maxDetour as "unknown" after loading finishes
-          setDetourMap((prev) => {
-            const next = { ...prev };
-            for (const f of batch) next[f.properties.id] = -1;
-            return next;
-          });
+        if (!res.ok || !res.body) {
+          // Mark all as failed
+          setDetourMap(Object.fromEntries(eligible.map((f) => [f.properties.id, -1])));
+          setDetoursLoading(false);
+          return;
         }
+
+        // Read NDJSON stream, flush to React state every DETOUR_FLUSH_MS
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let pending: Record<string, number> = {};
+        let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+        function flush() {
+          flushTimer = null;
+          const batch = pending;
+          pending = {};
+          setDetourMap((prev) => ({ ...prev, ...batch }));
+        }
+
+        function scheduleFlush() {
+          if (flushTimer == null) {
+            flushTimer = setTimeout(flush, DETOUR_FLUSH_MS);
+          }
+        }
+
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop()!; // keep incomplete trailing chunk
+
+          for (const line of lines) {
+            if (!line) continue;
+            try {
+              const { id, detourMin } = JSON.parse(line);
+              pending[id] = detourMin;
+            } catch { /* skip malformed line */ }
+          }
+
+          if (Object.keys(pending).length > 0) scheduleFlush();
+        }
+
+        // Flush any remaining results
+        if (flushTimer != null) clearTimeout(flushTimer);
+        if (Object.keys(pending).length > 0) flush();
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setDetourMap(Object.fromEntries(eligible.map((f) => [f.properties.id, -1])));
       }
       if (!controller.signal.aborted) setDetoursLoading(false);
     })();

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -277,8 +277,12 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
     detourAbortRef.current = controller;
     setDetoursLoading(true);
 
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
     (async () => {
       const coords = route.geometry.coordinates as [number, number][];
+      const eligibleIds = new Set(eligible.map((f) => f.properties.id));
+      const seen = new Set<string>();
 
       try {
         const res = await fetch("/api/route-detour", {
@@ -297,9 +301,10 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
         });
 
         if (!res.ok || !res.body) {
-          // Mark all as failed
-          setDetourMap(Object.fromEntries(eligible.map((f) => [f.properties.id, -1])));
-          setDetoursLoading(false);
+          if (!controller.signal.aborted) {
+            setDetourMap(Object.fromEntries(eligible.map((f) => [f.properties.id, -1])));
+            setDetoursLoading(false);
+          }
           return;
         }
 
@@ -308,10 +313,10 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
         const decoder = new TextDecoder();
         let buffer = "";
         let pending: Record<string, number> = {};
-        let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
         function flush() {
           flushTimer = null;
+          if (controller.signal.aborted) return;
           const batch = pending;
           pending = {};
           setDetourMap((prev) => ({ ...prev, ...batch }));
@@ -336,23 +341,32 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
             try {
               const { id, detourMin } = JSON.parse(line);
               pending[id] = detourMin;
+              seen.add(id);
             } catch { /* skip malformed line */ }
           }
 
           if (Object.keys(pending).length > 0) scheduleFlush();
         }
 
-        // Flush any remaining results
-        if (flushTimer != null) clearTimeout(flushTimer);
-        if (Object.keys(pending).length > 0) flush();
+        // Flush remaining results
+        if (flushTimer != null) { clearTimeout(flushTimer); flushTimer = null; }
+        if (!controller.signal.aborted && Object.keys(pending).length > 0) flush();
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
-        setDetourMap(Object.fromEntries(eligible.map((f) => [f.properties.id, -1])));
+        // Only mark unseen stations as failed — keep already-flushed successes
+        if (!controller.signal.aborted) {
+          const failed: Record<string, number> = {};
+          for (const id of eligibleIds) { if (!seen.has(id)) failed[id] = -1; }
+          if (Object.keys(failed).length > 0) setDetourMap((prev) => ({ ...prev, ...failed }));
+        }
       }
       if (!controller.signal.aborted) setDetoursLoading(false);
     })();
 
-    return () => { controller.abort(); };
+    return () => {
+      controller.abort();
+      if (flushTimer != null) { clearTimeout(flushTimer); flushTimer = null; }
+    };
   }, [primaryStations, routeState]);
 
   // Enrich primary stations with real detour values

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -13,7 +13,9 @@ import { SearchPanel } from "@/components/search/search-panel";
 
 // Debounce interval (ms) for batching per-station stream updates into
 // a single React state update, avoiding excessive re-renders.
-const DETOUR_FLUSH_MS = 150;
+const detourFlushMs = 150;
+// Must match the .max() on the detour API schema
+const detourChunkSize = 500;
 
 interface Props {
   defaultFuel: string;
@@ -278,88 +280,105 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
     setDetoursLoading(true);
 
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    let pending: Record<string, number> = {};
+
+    function flush() {
+      flushTimer = null;
+      if (controller.signal.aborted) return;
+      const batch = pending;
+      pending = {};
+      setDetourMap((prev) => ({ ...prev, ...batch }));
+    }
+
+    function scheduleFlush() {
+      if (flushTimer == null) {
+        flushTimer = setTimeout(flush, detourFlushMs);
+      }
+    }
+
+    // Backfill unseen stations as -1 so they don't bypass detour filter
+    function backfillUnseen(ids: Set<string>, seen: Set<string>) {
+      if (controller.signal.aborted) return;
+      const failed: Record<string, number> = {};
+      for (const id of ids) { if (!seen.has(id)) failed[id] = -1; }
+      if (Object.keys(failed).length > 0) setDetourMap((prev) => ({ ...prev, ...failed }));
+    }
 
     (async () => {
       const coords = route.geometry.coordinates as [number, number][];
       const eligibleIds = new Set(eligible.map((f) => f.properties.id));
       const seen = new Set<string>();
 
-      try {
-        const res = await fetch("/api/route-detour", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            stations: eligible.map((f) => ({
-              id: f.properties.id,
-              lon: f.geometry.coordinates[0],
-              lat: f.geometry.coordinates[1],
-              routeFraction: f.properties.routeFraction,
-            })),
-            routeCoordinates: coords,
-          }),
-          signal: controller.signal,
-        });
+      // Chunk eligible stations so each request stays within the API's .max(500)
+      for (let offset = 0; offset < eligible.length; offset += detourChunkSize) {
+        if (controller.signal.aborted) return;
+        const chunk = eligible.slice(offset, offset + detourChunkSize);
 
-        if (!res.ok || !res.body) {
-          if (!controller.signal.aborted) {
-            setDetourMap(Object.fromEntries(eligible.map((f) => [f.properties.id, -1])));
-            setDetoursLoading(false);
-          }
-          return;
-        }
+        try {
+          const res = await fetch("/api/route-detour", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              stations: chunk.map((f) => ({
+                id: f.properties.id,
+                lon: f.geometry.coordinates[0],
+                lat: f.geometry.coordinates[1],
+                routeFraction: f.properties.routeFraction,
+              })),
+              routeCoordinates: coords,
+            }),
+            signal: controller.signal,
+          });
 
-        // Read NDJSON stream, flush to React state every DETOUR_FLUSH_MS
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let pending: Record<string, number> = {};
-
-        function flush() {
-          flushTimer = null;
-          if (controller.signal.aborted) return;
-          const batch = pending;
-          pending = {};
-          setDetourMap((prev) => ({ ...prev, ...batch }));
-        }
-
-        function scheduleFlush() {
-          if (flushTimer == null) {
-            flushTimer = setTimeout(flush, DETOUR_FLUSH_MS);
-          }
-        }
-
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop()!; // keep incomplete trailing chunk
-
-          for (const line of lines) {
-            if (!line) continue;
-            try {
-              const { id, detourMin } = JSON.parse(line);
-              pending[id] = detourMin;
-              seen.add(id);
-            } catch { /* skip malformed line */ }
+          if (!res.ok || !res.body) {
+            // Mark this chunk as failed, continue to next chunk
+            if (!controller.signal.aborted) {
+              setDetourMap((prev) => {
+                const next = { ...prev };
+                for (const f of chunk) { next[f.properties.id] = -1; seen.add(f.properties.id); }
+                return next;
+              });
+            }
+            continue;
           }
 
-          if (Object.keys(pending).length > 0) scheduleFlush();
-        }
+          // Read NDJSON stream
+          const reader = res.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
 
-        // Flush remaining results
-        if (flushTimer != null) { clearTimeout(flushTimer); flushTimer = null; }
-        if (!controller.signal.aborted && Object.keys(pending).length > 0) flush();
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        // Only mark unseen stations as failed — keep already-flushed successes
-        if (!controller.signal.aborted) {
-          const failed: Record<string, number> = {};
-          for (const id of eligibleIds) { if (!seen.has(id)) failed[id] = -1; }
-          if (Object.keys(failed).length > 0) setDetourMap((prev) => ({ ...prev, ...failed }));
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop()!;
+
+            for (const line of lines) {
+              if (!line) continue;
+              try {
+                const { id, detourMin } = JSON.parse(line);
+                pending[id] = detourMin;
+                seen.add(id);
+              } catch { /* skip malformed line */ }
+            }
+
+            if (Object.keys(pending).length > 0) scheduleFlush();
+          }
+
+          // Flush remaining from this chunk
+          if (flushTimer != null) { clearTimeout(flushTimer); flushTimer = null; }
+          if (Object.keys(pending).length > 0) flush();
+        } catch (err) {
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          // Mark unseen stations in this chunk as failed, keep flushed successes
+          backfillUnseen(new Set(chunk.map((f) => f.properties.id)), seen);
         }
       }
+
+      // Backfill any stations never seen across all chunks (skipped lines, etc.)
+      backfillUnseen(eligibleIds, seen);
       if (!controller.signal.aborted) setDetoursLoading(false);
     })();
 

--- a/src/components/search/search-panel.tsx
+++ b/src/components/search/search-panel.tsx
@@ -781,8 +781,9 @@ export function SearchPanel({
               max={25}
               step={1}
               value={corridorKm}
+              disabled={detoursLoading}
               onChange={(e) => onCorridorKmChange?.(parseInt(e.target.value))}
-              className="mt-1 h-1 w-full cursor-pointer touch-none accent-emerald-500"
+              className={`mt-1 h-1 w-full touch-none accent-emerald-500 ${detoursLoading ? "cursor-not-allowed opacity-40" : "cursor-pointer"}`}
             />
           </div>
           {stationLegMsg && (

--- a/src/lib/valhalla.ts
+++ b/src/lib/valhalla.ts
@@ -123,6 +123,7 @@ export async function getRoute(
 export async function getRouteDuration(
   locations: { lat: number; lon: number }[],
   costing: string = "auto",
+  signal?: AbortSignal,
 ): Promise<number | null> {
   if (!VALHALLA_URL) return null;
 
@@ -135,7 +136,9 @@ export async function getRouteDuration(
       directions_options: { units: "kilometers" },
       directions_type: "none",
     }),
-    signal: AbortSignal.timeout(5000),
+    signal: signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(5000)])
+      : AbortSignal.timeout(5000),
   });
 
   if (!res.ok) return null;


### PR DESCRIPTION
## Summary
- Replaces batch-then-JSON detour API with **NDJSON streaming** — each station's detour appears on the map and in the station list the moment its Valhalla calls finish, instead of waiting for all 15 in a batch
- Client reads the stream with `ReadableStream.getReader()`, debounce-flushing to React state every 150ms to avoid excessive re-renders
- **Corridor slider disabled while detours are streaming** to prevent the user from accidentally restarting the calculation mid-stream
- Bumps version to **1.3.0**

## Changes
| File | What |
|------|------|
| `src/app/api/route-detour/route.ts` | Return `application/x-ndjson` stream instead of collected JSON |
| `src/components/home-client.tsx` | Single streaming request replaces batch loop; debounced flush |
| `src/components/search/search-panel.tsx` | Corridor slider disabled + dimmed during loading |
| `package.json` | Version bump 1.2.0 → 1.3.0 |

## Test plan
- [ ] Route from Sangüesa to Murcia — stations should appear one by one in the list and map
- [ ] Detour values should match previous batch results (same Valhalla calls)
- [ ] Corridor slider should be grayed out and non-interactive while detours stream
- [ ] Abort works: navigate away or clear route while streaming — no stale results appear
- [ ] maxDetour slider works during streaming (filters already-arrived stations in real-time)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.3.0

* **New Features**
  * Detour calculations now stream incremental results so station detours appear progressively and more responsively.
  * UI accumulates and debounces streamed updates, with a backfill step to mark unseen stations as unavailable.

* **Bug Fixes**
  * Distance range slider is disabled and visually dimmed while detour data is loading.
  * Requests now handle aborts and per-station failures without aborting the entire update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->