### PR TITLE
fix: full-route detour + zoom on station

### DIFF
--- a/src/app/api/route-detour/route.ts
+++ b/src/app/api/route-detour/route.ts
@@ -13,7 +13,6 @@ const stationSchema = z.object({
   id: z.string(),
   lon: z.number().min(-180).max(180),
   lat: z.number().min(-90).max(90),
-  routeFraction: z.number().min(0).max(1),
 });
 
 const coordSchema = z.tuple([
@@ -23,8 +22,9 @@ const coordSchema = z.tuple([
 
 const bodySchema = z.object({
   stations: z.array(stationSchema).min(1).max(500),
-  routeCoordinates: z.array(coordSchema).min(2).max(3000),
-  routeDurations: z.array(z.number().min(0)),
+  origin: coordSchema,
+  destination: coordSchema,
+  routeDuration: z.number().min(0),
 });
 
 /** Stream per-station detour times as NDJSON. Each line: `{"id":"…","detourMin":…}` */
@@ -44,114 +44,26 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { stations, routeCoordinates, routeDurations } = parseResult.data;
-  const numCoords = routeCoordinates.length;
-
-  // Pre-compute cumulative segment lengths for consistent length-based fractions.
-  // routeFraction from PostGIS (ST_LineLocatePoint) is a fraction of total line
-  // length, so we need length-based — not vertex-index-based — exit/rejoin windows.
-  const cumLen: number[] = [0];
-  for (let i = 1; i < numCoords; i++) {
-    const dx = routeCoordinates[i][0] - routeCoordinates[i - 1][0];
-    const dy = routeCoordinates[i][1] - routeCoordinates[i - 1][1];
-    cumLen.push(cumLen[i - 1] + Math.sqrt(dx * dx + dy * dy));
-  }
-  const totalLen = cumLen[numCoords - 1];
-
-  // Binary-search: find the vertex index where cumLen >= targetLen
-  function distToIndex(targetLen: number): number {
-    let lo = 0, hi = numCoords - 1;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (cumLen[mid] < targetLen) lo = mid + 1;
-      else hi = mid;
-    }
-    return lo;
-  }
+  const { stations, origin, destination, routeDuration } = parseResult.data;
 
   async function processStation(
     s: z.infer<typeof stationSchema>,
   ): Promise<{ id: string; detourMin: number }> {
     try {
-      if (totalLen === 0) return { id: s.id, detourMin: 0 };
+      // Full-route detour: route(origin → station → destination) - original duration.
+      // This computes the exact same delta the preview shows when a user clicks
+      // a station, guaranteeing the badge matches the preview.
+      const fullDuration = await getRouteDuration([
+        { lat: origin[1], lon: origin[0] },
+        { lat: s.lat, lon: s.lon },
+        { lat: destination[1], lon: destination[0] },
+      ], "auto", signal);
 
-      const stationDist = s.routeFraction * totalLen;
-      // Use a wide 15% window so Valhalla can find the truly optimal path
-      // through the station (not constrained to the nearest highway point).
-      const windowDist = totalLen * 0.15;
-      const exitDist = Math.max(0, stationDist - windowDist);
-      const rejoinDist = Math.min(totalLen, stationDist + windowDist);
+      if (fullDuration == null) return { id: s.id, detourMin: -1 };
 
-      let exitIdx = distToIndex(exitDist);
-      let rejoinIdx = Math.min(numCoords - 1, distToIndex(rejoinDist));
-
-      if (exitIdx === rejoinIdx) {
-        exitIdx = Math.max(0, exitIdx - 1);
-        rejoinIdx = Math.min(numCoords - 1, rejoinIdx + 1);
-        if (exitIdx === rejoinIdx) {
-          return { id: s.id, detourMin: -1 };
-        }
-      }
-
-      const exitCoord = routeCoordinates[exitIdx];
-      const rejoinCoord = routeCoordinates[rejoinIdx];
-
-      // Build the via-station route with through-waypoints pinning the highway
-      // segments before and after the station. This lets Valhalla find the
-      // optimal detour while keeping the highway portions on the correct road.
-      const locations: { lat: number; lon: number; type?: "through" }[] = [];
-
-      // Start: exit point
-      locations.push({ lat: exitCoord[1], lon: exitCoord[0] });
-
-      // Through-waypoints before station (pin highway)
-      const stationIdx = distToIndex(stationDist);
-      const preSeg = stationIdx - exitIdx;
-      if (preSeg > 4) {
-        for (let i = 1; i <= 3; i++) {
-          const idx = exitIdx + Math.round(i * preSeg / 4);
-          if (idx > exitIdx && idx < stationIdx) {
-            const c = routeCoordinates[idx];
-            locations.push({ lat: c[1], lon: c[0], type: "through" });
-          }
-        }
-      }
-
-      // Station (break point — actual stop)
-      locations.push({ lat: s.lat, lon: s.lon });
-
-      // Through-waypoints after station (pin highway)
-      const postSeg = rejoinIdx - stationIdx;
-      if (postSeg > 4) {
-        for (let i = 1; i <= 3; i++) {
-          const idx = stationIdx + Math.round(i * postSeg / 4);
-          if (idx > stationIdx && idx < rejoinIdx) {
-            const c = routeCoordinates[idx];
-            locations.push({ lat: c[1], lon: c[0], type: "through" });
-          }
-        }
-      }
-
-      // End: rejoin point
-      locations.push({ lat: rejoinCoord[1], lon: rejoinCoord[0] });
-
-      // Single Valhalla call: exit → [highway waypoints] → station → [highway waypoints] → rejoin
-      const viaStationDuration = await getRouteDuration(locations, "auto", signal);
-
-      if (viaStationDuration == null) {
-        return { id: s.id, detourMin: -1 };
-      }
-
-      // Exact baseline from per-point cumulative durations (built from Valhalla
-      // maneuver timing). This is the actual driving time for the exit→rejoin
-      // segment on the original route — no proportional approximation.
-      const baselineSec = routeDurations[rejoinIdx] - routeDurations[exitIdx];
-
-      const detourSec = viaStationDuration - baselineSec;
-      // Large negative means something went wrong
+      const detourSec = fullDuration - routeDuration;
       if (detourSec < -60) return { id: s.id, detourMin: -1 };
       const detourMin = Math.round(Math.max(0, detourSec) / 6) / 10;
-
       return { id: s.id, detourMin };
     } catch (err) {
       console.warn(`[route-detour] station ${s.id} failed:`, err);
@@ -165,7 +77,6 @@ export async function POST(request: NextRequest) {
 
   const stream = new ReadableStream({
     async start(controller) {
-      // Drain queue on client disconnect so workers stop picking up new stations
       const onAbort = () => { queue.length = 0; };
       signal.addEventListener("abort", onAbort);
       try {

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -167,14 +167,18 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           setPrimaryStations({ type: "FeatureCollection", features: [] });
         }
 
-        const primary = data.routes[0];
-        mapRef.current?.fitBounds(
-          [
-            [primary.bbox[0], primary.bbox[1]],
-            [primary.bbox[2], primary.bbox[3]],
-          ],
-          { padding: 60, duration: 1000 },
-        );
+        // Only fit bounds for normal route calculations.
+        // Station-leg routes keep the map centered on the station (from flyTo).
+        if (!isStationLeg) {
+          const primary = data.routes[0];
+          mapRef.current?.fitBounds(
+            [
+              [primary.bbox[0], primary.bbox[1]],
+              [primary.bbox[2], primary.bbox[3]],
+            ],
+            { padding: 60, duration: 1000 },
+          );
+        }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error("Route calculation failed:", err);
@@ -236,15 +240,31 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
       setStationLegRoutes(null);
       // Only clear loading if no normal route request is in flight
       if (!routeAbortRef.current) setIsRouteLoading(false);
+      // Restore map to full route view
+      const route = routeState?.routes[routeState.primaryIndex];
+      if (route) {
+        mapRef.current?.fitBounds(
+          [[route.bbox[0], route.bbox[1]], [route.bbox[2], route.bbox[3]]],
+          { padding: 60, duration: 800 },
+        );
+      }
     }
-  }, []);
+  }, [routeState]);
 
   const handleClearStationLeg = useCallback(() => {
     if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
     setStationLegRoutes(null);
     setSelectedStationId(null);
     if (!routeAbortRef.current) setIsRouteLoading(false);
-  }, []);
+    // Restore map to full route view
+    const route = routeState?.routes[routeState.primaryIndex];
+    if (route) {
+      mapRef.current?.fitBounds(
+        [[route.bbox[0], route.bbox[1]], [route.bbox[2], route.bbox[3]]],
+        { padding: 60, duration: 800 },
+      );
+    }
+  }, [routeState]);
 
   const handleFlyTo = useCallback((coords: [number, number], stationId?: string) => {
     mapRef.current?.flyTo({ center: coords, zoom: 14, duration: 1500 });
@@ -340,10 +360,10 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
                 id: f.properties.id,
                 lon: f.geometry.coordinates[0],
                 lat: f.geometry.coordinates[1],
-                routeFraction: f.properties.routeFraction,
               })),
-              routeCoordinates: coords,
-              routeDurations: route.durations ?? [],
+              origin: coords[0],
+              destination: coords[coords.length - 1],
+              routeDuration: route.duration,
             }),
             signal: controller.signal,
           });

--- a/src/lib/valhalla.ts
+++ b/src/lib/valhalla.ts
@@ -215,8 +215,8 @@ export async function getRouteDuration(
       directions_type: "none",
     }),
     signal: signal
-      ? AbortSignal.any([signal, AbortSignal.timeout(5000)])
-      : AbortSignal.timeout(5000),
+      ? AbortSignal.any([signal, AbortSignal.timeout(10000)])
+      : AbortSignal.timeout(10000),
   });
 
   if (!res.ok) return null;


### PR DESCRIPTION
## Summary
- **Detour accuracy**: Drops the windowed approach (exit/rejoin/through-waypoints/baseline estimation) entirely. Now computes `route(origin → station → destination) - originalDuration` for each station — the exact same delta the preview shows when you click. The route-detour endpoint is now ~100 lines instead of ~200.
- **Visible streaming**: Full-route Valhalla calls take ~300-500ms each (vs ~50ms for windowed segments). With 8 concurrent workers and 200 stations, results stream over 10+ seconds, making the NDJSON progressive loading visible in the UI.
- **Zoom fix**: Selecting a station keeps the map centered on the station (zoom 14) instead of fitting the new route bounds. Deselecting restores the full route view.

## Test plan
- [ ] Route Sangüesa/Zaragoza → Murcia, verify Erla detour badge shows ~12 min
- [ ] Watch station detour badges appear progressively (not all at once)
- [ ] Click a station → map stays centered on station, not the route
- [ ] Deselect station → map fits back to full route
- [ ] Click station in sidebar → same zoom behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Station route previews no longer automatically adjust the map viewport; map stays in place during station leg reviews
  * Map viewport restores to full route bounds when deselecting a station
  * Increased route request timeout to improve reliability with slower network connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->