### PR TITLE
fix: station zoom + progressive sidebar list

### DIFF
--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -48,6 +48,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   const stationLegAbortRef = useRef<AbortController | null>(null);
   const [mapCenter, setMapCenter] = useState<[number, number]>(center);
   const [selectedStationId, setSelectedStationId] = useState<string | null>(null);
+  const selectedStationCoordsRef = useRef<[number, number] | null>(null);
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
   const [maxDetour, setMaxDetour] = useState<number | null>(null);
   const [stationsLoading, setStationsLoading] = useState(false);
@@ -167,9 +168,13 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           setPrimaryStations({ type: "FeatureCollection", features: [] });
         }
 
-        // Only fit bounds for normal route calculations.
-        // Station-leg routes keep the map centered on the station (from flyTo).
-        if (!isStationLeg) {
+        if (isStationLeg) {
+          // Re-center on the station after route calculation completes.
+          // The initial flyTo may have been interrupted by the render cycle.
+          if (selectedStationCoordsRef.current) {
+            mapRef.current?.flyTo({ center: selectedStationCoordsRef.current, zoom: 14, duration: 500 });
+          }
+        } else {
           const primary = data.routes[0];
           mapRef.current?.fitBounds(
             [
@@ -234,6 +239,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
 
   const handleSelectStation = useCallback((id: string | null) => {
     setSelectedStationId(id);
+    if (id == null) selectedStationCoordsRef.current = null;
     // Deselect clears station-leg preview — search-panel's effect handles waypoint cleanup
     if (id == null) {
       if (stationLegAbortRef.current) { stationLegAbortRef.current.abort(); stationLegAbortRef.current = null; }
@@ -268,7 +274,10 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
 
   const handleFlyTo = useCallback((coords: [number, number], stationId?: string) => {
     mapRef.current?.flyTo({ center: coords, zoom: 14, duration: 1500 });
-    if (stationId) setSelectedStationId(stationId);
+    if (stationId) {
+      selectedStationCoordsRef.current = coords;
+      setSelectedStationId(stationId);
+    }
   }, []);
 
   const handlePrimaryStationsChange = useCallback((stations: StationsGeoJSONCollection) => {

--- a/src/components/search/search-panel.tsx
+++ b/src/components/search/search-panel.tsx
@@ -457,12 +457,14 @@ export function SearchPanel({
     ?? [];
 
   // Station list: filtered by price and detour, sorted by user selection.
-  // Stations whose detour is still unknown (null) pass the detour filter
-  // and sort to the end when sorting by detour, so they don't optimistically
-  // appear as "0 min" during progressive loading.
+  // During detour loading, only show stations with known detour values so
+  // rows appear progressively as NDJSON results stream in.
   const stationList = allCorridorStations
-    .filter((f) => (maxPrice == null || f.properties.price == null || f.properties.price <= maxPrice)
-      && (maxDetour == null || f.properties.detourMin == null || (f.properties.detourMin >= 0 && f.properties.detourMin <= maxDetour)))
+    .filter((f) => {
+      if (detoursLoading && f.properties.detourMin == null) return false;
+      return (maxPrice == null || f.properties.price == null || f.properties.price <= maxPrice)
+        && (maxDetour == null || f.properties.detourMin == null || (f.properties.detourMin >= 0 && f.properties.detourMin <= maxDetour));
+    })
     .sort((a, b) => {
       if (sortBy === "price") {
         const pa = a.properties.price, pb = b.properties.price;


### PR DESCRIPTION
## Summary
- **Zoom**: After station-leg route completes, explicitly re-centers on the station (flyTo with 500ms duration). The initial flyTo could be interrupted by React's render cycle. A ref stores the selected station's coordinates so the callback can re-apply them. Deselecting restores full-route fitBounds.
- **Progressive sidebar**: During detour loading, station rows are only shown once their detour value is known. As NDJSON results stream in (one every ~300-500ms), rows appear progressively instead of all at once. Once loading finishes, any remaining stations (failed detours) become visible.

## Test plan
- [ ] Click station in sidebar → map centers on station, stays there after route recalculates
- [ ] Click station on map → same centering behavior
- [ ] Deselect station → map fits full route
- [ ] Plan a route → watch sidebar station list populate progressively as detours stream in
- [ ] Verify station count in header updates as rows appear