### PR TITLE
chore: complete FUNDING.yml with all sponsorship platforms

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,4 @@
 github: geiserx
+patreon: geiser
+buy_me_a_coffee: geiser
+thanks_dev: u/gh/geiserx


### PR DESCRIPTION
Complete the FUNDING.yml which only had `github: geiserx`.

Added: Patreon, Buy Me a Coffee, and thanks.dev sponsorship links.