### PR TITLE
fix(ci): add setup-node to auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -28,6 +28,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Get latest tag and bump patch
         id: bump
         run: |


### PR DESCRIPTION
## Summary
- Adds `actions/setup-node@v4` with `node-version: '22'` to the auto-tag workflow
- Fixes workflow failure on self-hosted runners where Node.js/npm aren't pre-installed
- The `node -p` and `npm version` commands in the "Sync package.json version" step require Node to be available

## Context
All other workflows (`ci.yml`) already use `actions/setup-node@v6`. Only `auto-tag.yml` was missing it.