### PR TITLE
fix(ci): build arm64 image via QEMU on the X64 runner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,7 +70,10 @@ jobs:
           cache-to: type=gha,mode=max,scope=amd64
 
   build-arm64:
-    runs-on: [self-hosted, Linux, ARM64]
+    # No native ARM64 self-hosted runner exists, so build arm64 via QEMU
+    # emulation on the X64 runner. Slower than native but keeps the multi-arch
+    # manifest (:tag combining -amd64 + -arm64) working without extra hardware.
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       packages: write
@@ -79,6 +82,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0


### PR DESCRIPTION
## Summary
`build-arm64` in `docker-publish.yml` targeted a `[self-hosted, Linux, ARM64]` runner that isn't registered, so the job queued indefinitely and the `manifest` job (which creates the unsuffixed multi-arch `:1.5.0` tag) never ran. Releases since **v1.4.36** (May 18) silently shipped **amd64-only** (`-amd64`-suffixed tags only); v1.4.37/v1.4.38 Docker Publish runs were cancelled for the same reason.

Fix: build arm64 under **QEMU emulation on the existing X64 runner** (`watchtower-pumperly`) — the pre-split design. Adds the `setup-qemu-action` step and changes `build-arm64`'s `runs-on` to the X64 runner.

## Trade-off
- amd64 + arm64 now share the single X64 runner, so they serialize (slower wall-clock) and arm64 builds via emulation (slower still). Acceptable vs. needing dedicated ARM64 hardware. If a native ARM64 runner is added later, revert `runs-on` to `[self-hosted, Linux, ARM64]` and drop the QEMU step.

## After merge
- Re-run Docker Publish for **v1.5.0** (`workflow_dispatch` with `tag: v1.5.0`) so the multi-arch `:1.5.0` / `:v1.5.0` / `:latest` manifest is finally created (currently only `:1.5.0-amd64` exists on Docker Hub).

## Test plan
- [x] YAML validates
- [x] Actions remain SHA-pinned (QEMU action pinned to the same SHA used by build-amd64's sibling history)
- [ ] Docker Publish completes all 3 jobs (build-amd64, build-arm64, manifest) and `drumsergio/pumperly:1.5.0` resolves as a multi-arch manifest