### PR TITLE
fix: default max detour to 5 minutes

### DIFF
--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -41,7 +41,9 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   const [selectedStationId, setSelectedStationId] = useState<string | null>(null);
   const selectedStationCoordsRef = useRef<[number, number] | null>(null);
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
-  const [maxDetour, setMaxDetour] = useState<number | null>(null);
+  // Default to a 5-minute max detour so users see only worthwhile stops; they
+  // can widen it (up to "no limit") via the slider.
+  const [maxDetour, setMaxDetour] = useState<number | null>(5);
   const [detourBasis, setDetourBasis] = useState<DetourBasis>("selected");
   const [stationsLoading, setStationsLoading] = useState(false);
   const [stationsError, setStationsError] = useState(false);
@@ -94,7 +96,7 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   const handleFuelChange = useCallback((fuel: FuelType) => {
     setSelectedFuel(fuel);
     setMaxPrice(null);
-    setMaxDetour(null);
+    setMaxDetour(5);
   }, []);
 
   const handleMapMove = useCallback((newCenter: [number, number]) => {

--- a/src/components/search/autocomplete-input.test.tsx
+++ b/src/components/search/autocomplete-input.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { AutocompleteInput } from "./autocomplete-input";
+import type { PhotonResult } from "@/lib/photon";
+
+vi.mock("@/lib/i18n", () => ({ useI18n: () => ({ t: (k: string) => k }) }));
+
+const RESULT: PhotonResult = {
+  name: "Madrid",
+  city: "Madrid",
+  state: "Comunidad de Madrid",
+  coordinates: [-3.7, 40.4],
+} as PhotonResult;
+
+// Controlled wrapper mirroring how SearchPanel drives the input: onSelect feeds
+// the formatted label back into `value` (as handleDestSelect/handleOriginSelect do).
+function Harness({
+  withLocation,
+  onSelect,
+}: {
+  withLocation?: boolean;
+  onSelect?: (r: PhotonResult) => void;
+}) {
+  const [value, setValue] = useState("");
+  return (
+    <AutocompleteInput
+      placeholder="dest"
+      value={value}
+      onChange={setValue}
+      onSelect={(r) => {
+        setValue(`${r.name}, ${r.city}`);
+        onSelect?.(r);
+      }}
+      {...(withLocation
+        ? { locationLabel: "My location", onLocationSelect: () => {} }
+        : {})}
+    />
+  );
+}
+
+describe("AutocompleteInput — dropdown closes on selection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => [RESULT] }));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // user-event drives real pointer + focus semantics, so it exercises the
+  // onMouseDown preventDefault (which keeps focus on the input) — the regression
+  // surface fireEvent cannot reach.
+  it("hides the suggestion list after a result is picked (destination)", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("dest");
+
+    await user.type(input, "Mad");
+    const option = await screen.findByText("Madrid", {}, { timeout: 2000 });
+
+    await user.click(option);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Comunidad de Madrid")).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides the suggestion list after a result is picked (origin with My location)", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<Harness withLocation onSelect={onSelect} />);
+    const input = screen.getByPlaceholderText("dest");
+
+    await user.type(input, "Mad");
+    const option = await screen.findByText("Madrid", {}, { timeout: 2000 });
+
+    await user.click(option);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    // Neither the geocoded suggestion nor the "My location" row should remain
+    // (the input stays focused due to preventDefault, so the location branch
+    // must NOT re-open once a value is set).
+    await waitFor(() => {
+      expect(screen.queryByText("Comunidad de Madrid")).not.toBeInTheDocument();
+      expect(screen.queryByText("My location")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/search/search-panel.test.tsx
+++ b/src/components/search/search-panel.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SearchPanel } from "./search-panel";
+import type { PhotonResult } from "@/lib/photon";
+
+vi.mock("@/lib/i18n", () => ({ useI18n: () => ({ t: (k: string) => k }) }));
+vi.mock("@/lib/currency", () => ({
+  useCurrency: () => ({ symbol: "€", formatPrice: (n: number) => n.toFixed(3) }),
+  CURRENCIES: [{ code: "EUR", symbol: "€", decimals: 3 }],
+}));
+// Dumb children — not under test here.
+vi.mock("./route-alternatives", () => ({ RouteAlternatives: () => null }));
+vi.mock("./station-results", () => ({ StationResults: () => null }));
+
+const MADRID: PhotonResult = {
+  name: "Madrid", city: "Madrid", state: "Comunidad de Madrid", coordinates: [-3.7, 40.4],
+} as PhotonResult;
+
+function renderPanel() {
+  return render(
+    <SearchPanel
+      mapCenter={[-3.7, 40.4]}
+      onFlyTo={() => {}}
+      onRoute={() => {}}
+      onClearRoute={() => {}}
+      routes={null}
+      primaryRouteIndex={0}
+      isLoading={false}
+    />,
+  );
+}
+
+describe("SearchPanel — autocomplete dropdown closes on selection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => [MADRID] }));
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("closes the origin suggestion list after picking a result", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    const origin = screen.getByPlaceholderText("search.placeholder");
+    await user.type(origin, "Mad");
+
+    const option = await screen.findByText("Madrid", {}, { timeout: 2000 });
+    await user.click(option);
+
+    // After selection the suggestion list (the geocoded row's secondary text)
+    // must be gone.
+    await waitFor(() => {
+      expect(screen.queryByText("Comunidad de Madrid")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `maxDetour` now defaults to **5 min** (was "no limit") on initial load and resets to 5 on fuel change, so users see only worthwhile stops by default. The slider still goes up to "no limit".
- Adds regression tests confirming the autocomplete dropdown closes on selection (component-level + full SearchPanel, with real focus/pointer semantics).

## Test plan
- [x] tsc clean
- [x] 475 tests pass (node + components)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detour distance constraint to reset to default value when changing fuel selection.

* **Tests**
  * Added test coverage for autocomplete dropdown behavior in search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->