### PR TITLE
fix: zoom to a shared route on open (deep-link fitBounds race)

### DIFF
--- a/src/components/home-client.deeplink.test.tsx
+++ b/src/components/home-client.deeplink.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
-import { forwardRef, useEffect, useImperativeHandle } from "react";
+import { forwardRef, useEffect } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
 import type { StationsGeoJSONCollection } from "@/types/station";
 import { HomeClient } from "./home-client";
@@ -14,6 +14,10 @@ let searchPanelProps: Record<string, unknown> = {};
 // mimicking the real MapView (corridor stations with a route, on-screen bbox
 // stations without). Set per-test; the mock lifts it once the map is "ready".
 let liftedStations: StationsGeoJSONCollection = { type: "FeatureCollection", features: [] };
+// When set, the mock MapView exposes onMapReady here instead of firing it on
+// commit, so a test can simulate the map becoming ready AFTER a route resolves.
+let deferredMapReady: (() => void) | null = null;
+let deferMapReady = false;
 
 // Pass-through providers + no-op navbar / detour hook.
 vi.mock("@/lib/theme", () => ({ ThemeProvider: ({ children }: { children: React.ReactNode }) => children }));
@@ -28,19 +32,32 @@ vi.mock("@/lib/use-detour-stream", () => ({ useDetourStream: () => ({ detourMap:
 // MapView is a forwardRef. The REAL MapView assigns its MapRef inside MapLibre's
 // async `onLoad`, then calls `onMapReady()` and lifts on-screen stations via
 // `onPrimaryStationsChange`. We replicate that ordering from a post-commit effect
-// (ref already wired via useImperativeHandle) so the deep-link camera move — now
-// triggered from the map-ready path, not a bare mount effect — can be asserted,
-// and so the parent can resolve a station deep-link against the lifted features.
+// — wiring the ref at the same moment onMapReady fires — so the deep-link camera
+// move (now triggered from the map-ready path, not a bare mount effect) can be
+// asserted, and so the parent can resolve a station deep-link against the lifted
+// features.
 vi.mock("@/components/map/map-view", () => ({
   MapView: forwardRef<MapRef, Record<string, unknown>>(function MockMapView(props, ref) {
-    useImperativeHandle(ref, () => ({ flyTo, fitBounds } as unknown as MapRef));
     const onMapReady = props.onMapReady as (() => void) | undefined;
     const onPrimaryStationsChange = props.onPrimaryStationsChange as
       | ((s: StationsGeoJSONCollection) => void)
       | undefined;
-    useEffect(() => {
+    // The REAL MapView assigns mapRef inside MapLibre's onLoad — i.e. the ref
+    // only becomes non-null at the moment the map is ready. Model that: wire the
+    // ref + fire onMapReady together. When deferred, neither happens until the
+    // test calls deferredMapReady(), reproducing "route resolves before map ready".
+    const wireReady = () => {
+      (ref as React.MutableRefObject<MapRef | null>).current = { flyTo, fitBounds } as unknown as MapRef;
       onMapReady?.();
+    };
+    useEffect(() => {
+      if (deferMapReady) {
+        deferredMapReady = wireReady;
+      } else {
+        wireReady();
+      }
       onPrimaryStationsChange?.(liftedStations);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [onMapReady, onPrimaryStationsChange]);
     return null;
   }),
@@ -97,6 +114,8 @@ describe("HomeClient — deep-link read on load", () => {
     fitBounds.mockClear();
     searchPanelProps = {};
     liftedStations = { type: "FeatureCollection", features: [] };
+    deferredMapReady = null;
+    deferMapReady = false;
   });
   afterEach(() => {
     window.history.replaceState(null, "", "/");
@@ -204,5 +223,49 @@ describe("HomeClient — deep-link read on load", () => {
     expect(searchPanelProps.initialRoute).toBeNull();
     expect(flyTo).not.toHaveBeenCalled();
     expect(searchPanelProps.selectedFuel).toBe("E5");
+  });
+
+  // A route bbox (Murcia-ish) the mocked /api/route returns.
+  const ROUTE_BBOX: [number, number, number, number] = [-1.13054, 37.96142, -1.08531, 37.99238];
+  function mockRouteFetch() {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ routes: [{ geometry: { type: "LineString", coordinates: [] }, distance: 5, duration: 300, bbox: ROUTE_BBOX }] }),
+    })));
+  }
+
+  it("fits the map to a deep-link route once it resolves (map already ready)", async () => {
+    mockRouteFetch();
+    window.history.replaceState(null, "", "/es?from=37.96142,-1.08531&to=37.99238,-1.13054&fuel=B7");
+    renderHome();
+
+    // Drive the route fetch the way SearchPanel's prefill would (onRoute = handleRoute).
+    const onRoute = searchPanelProps.onRoute as (o: [number, number], d: [number, number]) => void;
+    onRoute([-1.08531, 37.96142], [-1.13054, 37.99238]);
+
+    // The camera frames the route bbox — not the default country view.
+    await waitFor(() => expect(fitBounds).toHaveBeenCalled());
+    const [bounds] = fitBounds.mock.calls.at(-1)!;
+    expect(bounds).toEqual([[ROUTE_BBOX[0], ROUTE_BBOX[1]], [ROUTE_BBOX[2], ROUTE_BBOX[3]]]);
+  });
+
+  it("fits a deep-link route even if it resolves BEFORE the map is ready (the bug)", async () => {
+    mockRouteFetch();
+    deferMapReady = true; // map ref/onLoad lands AFTER the route fetch
+    window.history.replaceState(null, "", "/es?from=37.96142,-1.08531&to=37.99238,-1.13054&fuel=B7");
+    renderHome();
+
+    const onRoute = searchPanelProps.onRoute as (o: [number, number], d: [number, number]) => void;
+    onRoute([-1.08531, 37.96142], [-1.13054, 37.99238]);
+
+    // Route resolved while the map was not ready → fitBounds was stashed, not lost.
+    await waitFor(() => expect(searchPanelProps.routes).not.toBeNull());
+    expect(fitBounds).not.toHaveBeenCalled();
+
+    // Map becomes ready → the stashed route bbox is applied.
+    deferredMapReady?.();
+    await waitFor(() => expect(fitBounds).toHaveBeenCalled());
+    const [bounds] = fitBounds.mock.calls.at(-1)!;
+    expect(bounds).toEqual([[ROUTE_BBOX[0], ROUTE_BBOX[1]], [ROUTE_BBOX[2], ROUTE_BBOX[3]]]);
   });
 });

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -100,6 +100,11 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   // shared target (station or route) wins the initial camera, not the user's
   // current location.
   const hasDeepLink = deepLink.route != null || deepLink.station != null;
+  // Holds a route bbox to fit once the map is ready. A deep-link route fetch can
+  // resolve BEFORE MapLibre's onLoad assigns mapRef, so fitBounds would no-op and
+  // the map would stay at the default view. We stash the bbox and apply it from
+  // handleMapReady when the ref is live.
+  const pendingRouteFitRef = useRef<[number, number, number, number] | null>(null);
   const [maxPrice, setMaxPrice] = useState<number | null>(null);
   // Default to a 5-minute max detour so users see only worthwhile stops; they
   // can widen it (up to "no limit") via the slider.
@@ -149,11 +154,20 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
   // the initial camera, so we move there and skip auto-geolocation entirely:
   //   - station deep-link: flyTo the shared coords here (the popup opens later,
   //     once matching features stream in and the resolve effect matches);
-  //   - route deep-link: SearchPanel's prefill triggers the route fetch, which
-  //     fitBounds the result — nothing to do here beyond not stealing the camera.
+  //   - route deep-link: the route fetch may have resolved before the map was
+  //     ready, leaving its fitBounds a no-op; apply the stashed bbox now so the
+  //     camera frames the shared route instead of the default country view.
   // Without a deep link, auto-geolocate as before (prompts if not yet decided).
   const handleMapReady = useCallback(() => {
     if (hasDeepLink) {
+      const pendingFit = pendingRouteFitRef.current;
+      if (pendingFit) {
+        pendingRouteFitRef.current = null;
+        mapRef.current?.fitBounds(
+          [[pendingFit[0], pendingFit[1]], [pendingFit[2], pendingFit[3]]],
+          { padding: 60, duration: 1000 },
+        );
+      }
       const target = deepLinkStationRef.current;
       if (target && target.lat != null && target.lng != null) {
         mapRef.current?.flyTo({ center: [target.lng, target.lat], zoom: 14, duration: 1500 });
@@ -249,13 +263,18 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           }
         } else {
           const primary = data.routes[0];
-          mapRef.current?.fitBounds(
-            [
-              [primary.bbox[0], primary.bbox[1]],
-              [primary.bbox[2], primary.bbox[3]],
-            ],
-            { padding: 60, duration: 1000 },
-          );
+          if (mapRef.current) {
+            mapRef.current.fitBounds(
+              [
+                [primary.bbox[0], primary.bbox[1]],
+                [primary.bbox[2], primary.bbox[3]],
+              ],
+              { padding: 60, duration: 1000 },
+            );
+          } else {
+            // Map not loaded yet (deep-link route resolved first) — fit once ready.
+            pendingRouteFitRef.current = primary.bbox;
+          }
         }
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;


### PR DESCRIPTION
## Summary
Opening a shared **route** link (`?from&to&via&fuel`) rendered the route but left the camera on the whole-Spain default view instead of framing the route.

**Root cause:** `handleRoute` calls `mapRef.fitBounds(...)` when the `/api/route` fetch resolves. For a deep-link route the prefill fires that fetch on mount, and it often resolves **before** MapLibre's async `onLoad` assigns `mapRef` — so `fitBounds` ran against a null ref (silent no-op) and the camera never moved. Same race class as the station-flyTo fix, which `handleRoute`'s fit wasn't covered by.

**Fix:** when the map isn't ready, stash the route bbox in `pendingRouteFitRef` and apply it from `handleMapReady` once the ref is live. Direct-fit path (map ready first) is unchanged.

## Test plan
- [x] tsc clean
- [x] 533 tests pass (+2 regression: fits when map-ready-first, and when the route resolves BEFORE map-ready — the bug)
- [x] next build ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-linked route camera behavior to correctly fit route bounds even when route data loads before the map is fully initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->