### PR TITLE
fix(map): route highlight stuck on route 0 / clicks ignored

### DIFF
--- a/src/components/home-client.route-select.test.tsx
+++ b/src/components/home-client.route-select.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { forwardRef, useEffect } from "react";
+import type { MapRef } from "react-map-gl/maplibre";
+import { HomeClient } from "./home-client";
+import type { Route } from "@/components/map/route-layer";
+
+// Capture the props each child receives so we can assert the exact wiring that
+// the route-highlight bug lived in (home-client → MapView displayRoutes).
+let mapViewProps: Record<string, unknown> = {};
+let searchPanelProps: Record<string, unknown> = {};
+
+vi.mock("@/lib/theme", () => ({ ThemeProvider: ({ children }: { children: React.ReactNode }) => children }));
+vi.mock("@/lib/currency", () => ({ CurrencyProvider: ({ children }: { children: React.ReactNode }) => children }));
+vi.mock("@/lib/i18n", () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => children,
+  useI18n: () => ({ t: (k: string) => k, locale: "es", setLocale: () => {} }),
+}));
+vi.mock("@/components/nav/navbar", () => ({ Navbar: () => null }));
+vi.mock("@/lib/use-detour-stream", () => ({ useDetourStream: () => ({ detourMap: {}, detoursLoading: false }) }));
+
+vi.mock("@/components/map/map-view", () => ({
+  MapView: forwardRef<MapRef, Record<string, unknown>>(function MockMapView(props, ref) {
+    // Capture in an effect (not during render) to stay a pure component.
+    useEffect(() => {
+      mapViewProps = props;
+      (ref as React.MutableRefObject<MapRef | null>).current = {
+        flyTo: vi.fn(), fitBounds: vi.fn(),
+      } as unknown as MapRef;
+      (props.onMapReady as (() => void) | undefined)?.();
+    }, [props, ref]);
+    return null;
+  }),
+}));
+
+// Capture SearchPanel props; also expose its onSelectRoute so the test can
+// simulate the user clicking an alternative route row.
+vi.mock("@/components/search/search-panel", () => ({
+  SearchPanel: (props: Record<string, unknown>) => {
+    useEffect(() => { searchPanelProps = props; }, [props]);
+    return null;
+  },
+}));
+
+const ROUTES: Route[] = [
+  { geometry: { type: "LineString", coordinates: [[-3.7, 40.4], [-3.6, 40.5]] }, distance: 6400, duration: 480, bbox: [-3.7, 40.4, -3.6, 40.5] },
+  { geometry: { type: "LineString", coordinates: [[-3.7, 40.4], [-3.5, 40.6]] }, distance: 8800, duration: 660, bbox: [-3.7, 40.4, -3.5, 40.6] },
+  { geometry: { type: "LineString", coordinates: [[-3.7, 40.4], [-3.4, 40.6]] }, distance: 8000, duration: 661, bbox: [-3.7, 40.4, -3.4, 40.6] },
+];
+
+function renderHome() {
+  return render(<HomeClient defaultFuel="E5" center={[-3.7, 40.4]} zoom={6} clusterStations={false} locale="es" />);
+}
+
+describe("HomeClient — route selection wiring to the map", () => {
+  beforeEach(() => {
+    mapViewProps = {};
+    searchPanelProps = {};
+    // /api/route returns our 3 alternatives.
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (String(url).includes("/api/route")) {
+        return { ok: true, json: async () => ({ routes: ROUTES }) } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    }));
+  });
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT put the map in pinned mode during normal browsing, and selecting an alternative updates the map's primaryRouteIndex", async () => {
+    renderHome();
+
+    // Drive a normal route calc the way SearchPanel's onRoute would.
+    const onRoute = searchPanelProps.onRoute as (o: [number, number], d: [number, number]) => void;
+    onRoute([-3.7, 40.4], [-3.6, 40.5]);
+
+    // After the route resolves, MapView must receive the 3 routes, primaryIndex 0,
+    // displayRoutes NULL (no station leg → not pinned), and a DEFINED onSelectRoute
+    // so route clicks work. This is the exact regression: displayRoutes used to
+    // fall back to routeState.routes, pinning the map to index 0 forever.
+    await waitFor(() => expect((mapViewProps.routes as Route[] | null)?.length).toBe(3));
+    expect(mapViewProps.displayRoutes).toBeNull();
+    expect(mapViewProps.primaryRouteIndex).toBe(0);
+    expect(typeof mapViewProps.onSelectRoute).toBe("function");
+
+    // Simulate selecting the 2nd alternative (what RouteAlternatives / a map
+    // route-line click does) → the map's primaryRouteIndex must move to 1.
+    (mapViewProps.onSelectRoute as (i: number) => void)(1);
+    await waitFor(() => expect(mapViewProps.primaryRouteIndex).toBe(1));
+    // Still not pinned, still clickable.
+    expect(mapViewProps.displayRoutes).toBeNull();
+    expect(typeof mapViewProps.onSelectRoute).toBe("function");
+  });
+});

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -517,7 +517,12 @@ export function HomeClient({ defaultFuel, center, zoom, clusterStations, locale 
           clusterStations={clusterStations}
           corridorKm={corridorKm}
           routes={routeState?.routes ?? null}
-          displayRoutes={stationLegRoutes ?? routeState?.routes ?? null}
+          // Only a real station-leg preview should put the map in "pinned"
+          // mode (highlight index 0, route-click disabled). Falling back to
+          // routeState.routes here made displayRoutes truthy for EVERY active
+          // route, so the map always highlighted route 0 and ignored clicks /
+          // the selected alternative. Pass the leg (or null), like SearchPanel.
+          displayRoutes={stationLegRoutes}
           primaryRouteIndex={routeState?.primaryIndex ?? 0}
           selectedStationId={selectedStationId}
           onSelectStation={handleSelectStation}

--- a/src/components/search/route-select.integration.test.tsx
+++ b/src/components/search/route-select.integration.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { SearchPanel } from "./search-panel";
+import type { Route } from "@/components/map/route-layer";
+import { formatDistance } from "@/lib/format";
+
+// Real RouteAlternatives + StationResults (NOT mocked) — this is an integration
+// test of the click → onSelectRoute → primaryRouteIndex → re-highlight round-trip
+// that the isolated unit tests don't exercise.
+vi.mock("@/lib/i18n", () => ({ useI18n: () => ({ t: (k: string) => k }) }));
+vi.mock("@/lib/currency", () => ({
+  useCurrency: () => ({ symbol: "€", formatPrice: (n: number) => n.toFixed(3) }),
+  CURRENCIES: [{ code: "EUR", symbol: "€", decimals: 3 }],
+}));
+
+function mk(distance: number, duration: number): Route {
+  return {
+    geometry: { type: "LineString", coordinates: [[-3.7, 40.4], [-3.6, 40.5]] },
+    distance,
+    duration,
+    bbox: [-3.7, 40.4, -3.6, 40.5],
+  };
+}
+// Three distinct distances so each row's distance text is unique & findable.
+const ROUTES: Route[] = [mk(6400, 480), mk(8800, 660), mk(8000, 661)];
+
+/** Mirrors home-client's routeState + handleSelectRoute exactly. Drives the
+ * SearchPanel through its real flow via `initialRoute` so its internal phase
+ * reaches "route" (which the mobile bottom sheet is gated on), exactly like the
+ * app after a route is calculated. */
+function Harness() {
+  const [routeState, setRouteState] = useState<{ routes: Route[]; primaryIndex: number } | null>(null);
+  const handleSelectRoute = (index: number) => {
+    setRouteState((prev) => {
+      if (!prev) return prev;
+      const route = prev.routes[index];
+      if (!route) return prev;
+      return { ...prev, primaryIndex: index };
+    });
+  };
+  // initialRoute → SearchPanel sets phase="route" and calls onRoute, which we
+  // resolve into routeState (home-client does the same in handleRoute).
+  const handleRoute = () => setRouteState({ routes: ROUTES, primaryIndex: 0 });
+  return (
+    <SearchPanel
+      mapCenter={[-3.7, 40.4]}
+      onFlyTo={() => {}}
+      onRoute={handleRoute}
+      onClearRoute={() => {}}
+      onSelectRoute={handleSelectRoute}
+      routes={routeState?.routes ?? null}
+      primaryRouteIndex={routeState?.primaryIndex ?? 0}
+      isLoading={false}
+      initialRoute={{ from: [-3.7, 40.4], to: [-3.6, 40.5], via: [] }}
+    />
+  );
+}
+
+// A RouteAlternatives row is a <button> containing the colored dot
+// (span.h-2\.5) and the distance text. The collapse toggle also shows the
+// selected distance but has no such dot, so this disambiguates. We read the
+// row's font-medium state off the DISTANCE span (selected rows are font-medium).
+function routeRow(route: Route): HTMLElement {
+  const dist = formatDistance(route.distance);
+  const btn = screen.getAllByRole("button").find(
+    (b) => b.textContent?.includes(dist) && b.querySelector("span.h-2\\.5.w-2\\.5"),
+  );
+  if (!btn) throw new Error(`route row for ${dist} not found`);
+  return btn;
+}
+/** True when the route row is the highlighted/primary one. */
+function isHighlighted(route: Route): boolean {
+  const dist = formatDistance(route.distance);
+  const row = routeRow(route);
+  // The distance span carries font-medium iff selected.
+  const distSpan = Array.from(row.querySelectorAll("span")).find((s) => s.textContent === dist);
+  return distSpan?.classList.contains("font-medium") ?? false;
+}
+
+describe("SearchPanel — route alternative selection (integration)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => [] }));
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("moves the highlight to an alternative route when it is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    // Routes arrive async (initialRoute → onRoute). Wait, then route 0 selected.
+    await waitFor(() => expect(isHighlighted(ROUTES[0])).toBe(true));
+    expect(isHighlighted(ROUTES[1])).toBe(false);
+
+    // Click the SECOND route (index 1).
+    await user.click(routeRow(ROUTES[1]));
+
+    // Highlight must move: route 1 now selected, route 0 no longer.
+    await waitFor(() => expect(isHighlighted(ROUTES[1])).toBe(true));
+    expect(isHighlighted(ROUTES[0])).toBe(false);
+  });
+
+  it("moves the highlight to the third route when clicked", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await waitFor(() => expect(isHighlighted(ROUTES[0])).toBe(true));
+    await user.click(routeRow(ROUTES[2]));
+    await waitFor(() => expect(isHighlighted(ROUTES[2])).toBe(true));
+    expect(isHighlighted(ROUTES[0])).toBe(false);
+    expect(isHighlighted(ROUTES[1])).toBe(false);
+  });
+
+  it("moves the highlight on MOBILE (route list inside the bottom sheet)", async () => {
+    // Stub matchMedia so isMobile=true → RouteAlternatives renders in the sheet.
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((q: string) => ({
+        matches: q.includes("max-width: 639px"),
+        media: q,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    // Confirm we're in the sheet (region landmark present) once routes resolve.
+    await waitFor(() =>
+      expect(screen.getByRole("region", { name: "sheet.routeAndStations" })).toBeInTheDocument(),
+    );
+    await waitFor(() => expect(isHighlighted(ROUTES[0])).toBe(true));
+
+    await user.click(routeRow(ROUTES[1]));
+    await waitFor(() => expect(isHighlighted(ROUTES[1])).toBe(true));
+    expect(isHighlighted(ROUTES[0])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Symptom

With 3 alternative routes, only one (route 0) is highlighted on the map, and clicking a different route doesn't move the highlight.

## Root cause

`home-client` passed `displayRoutes={stationLegRoutes ?? routeState?.routes ?? null}` to **MapView**. With no station leg active, this falls back to `routeState.routes`, making `displayRoutes` **truthy for every active route**.

MapView reads:
```tsx
primaryIndex={displayRoutes ? 0 : primaryRouteIndex}
onSelectRoute={displayRoutes ? undefined : onSelectRoute}
```

So whenever a route was active, the map **hardcoded the highlight to index 0** and **disabled route-line clicks** — the bold line never moved off route 0.

`displayRoutes` is meant to signal an active **station-leg preview** (a temporary "route through this station", which legitimately pins to index 0 and disables selection). The fallback wrongly triggered that mode during normal browsing.

## Fix

Pass `displayRoutes={stationLegRoutes}` (or null) — exactly what `SearchPanel` already receives. MapView still renders the line via `displayRoutes ?? routes`, so it draws from `routes` with the correct `primaryRouteIndex` and a working `onSelectRoute`. Station-leg previews are unaffected (`stationLegRoutes` is non-null then).

## Scope

**Pre-existing** since #17 (the station-leg feature) — **not** introduced by the mobile bottom sheet (#68). The sidebar/sheet list selection worked; only the map highlight was stuck.

## Tests

- `route-select.integration.test.tsx` — real `SearchPanel` + `RouteAlternatives`, asserts the click→highlight round-trip on **desktop and mobile (bottom sheet)**.
- `home-client.route-select.test.tsx` — asserts `HomeClient` passes MapView `displayRoutes=null` + a working `onSelectRoute` during browsing, and that selecting an alternative moves `primaryRouteIndex`. **Verified to fail against the buggy fallback** and pass with the fix.

## Verification

- `tsc` ✅ · `lint` 0 errors ✅ · `npm test` **552 passing** ✅ · `build` 31/31 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites to verify route selection workflows and map integration
  * Tests cover route switching and alternative selection behavior across devices

* **Bug Fixes**
  * Fixed route highlighting behavior on the map to only display during station-leg previews

<!-- end of auto-generated comment: release notes by coderabbit.ai -->