### PR TITLE
feat: static community station-data contribution path (#78)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -99,6 +99,8 @@ export async function register() {
   const { ArgentinaScraper } = await import("./scrapers/argentina");
   const { MexicoScraper } = await import("./scrapers/mexico");
   const { OCMScraper } = await import("./scrapers/ocm");
+  const { StaticScraper } = await import("./scrapers/static");
+  const { STATIC_DATASETS } = await import("./scrapers/data");
 
   const scraperFactories: Record<string, () => BaseScraper> = {
     ES: () => new SpainScraper(),
@@ -176,6 +178,13 @@ export async function register() {
     EV_AR: () => new OCMScraper("AR"),
     EV_MX: () => new OCMScraper("MX"),
   };
+
+  // Register community-contributed static datasets (see scrapers/data/README.md).
+  // Each is keyed STATIC_<SOURCE> and scrapes from committed data, no network.
+  for (const dataset of STATIC_DATASETS) {
+    const key = `STATIC_${dataset.source.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}`;
+    scraperFactories[key] = () => new StaticScraper(dataset);
+  }
 
   // Determine which countries to scrape
   // Enabling "ES" auto-enables "EV_ES" too (unless PUMPERLY_EV_ENABLED=0)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -183,6 +183,15 @@ export async function register() {
   // Each is keyed STATIC_<SOURCE> and scrapes from committed data, no network.
   for (const dataset of STATIC_DATASETS) {
     const key = `STATIC_${dataset.source.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}`;
+    if (key in scraperFactories) {
+      // Two sources that differ only in punctuation normalise to the same key
+      // (e.g. "community-us" vs "community_us"). Skip rather than silently
+      // overwrite — the static.test.ts registry guard fails CI on this too.
+      console.error(
+        `[scraper] Static dataset key collision: "${key}" (source "${dataset.source}") already registered — skipping.`,
+      );
+      continue;
+    }
     scraperFactories[key] = () => new StaticScraper(dataset);
   }
 

--- a/src/scrapers/data/README.md
+++ b/src/scrapers/data/README.md
@@ -1,0 +1,63 @@
+# Contributing station data
+
+Pumperly pulls most of its stations from live country-level APIs. But some
+places have **no API to scrape** — a whole country Pumperly doesn't cover yet, or
+just a city you happen to know well. This folder lets you add those stations by
+committing a plain data file. No API, no keys, no backend access — just a pull
+request.
+
+This is the perfect path for **EV charging** contributions and for **fuel
+stations in regions without an open data feed**.
+
+## How it works
+
+Each dataset is a `StaticDataset` (see [`../static.ts`](../static.ts)). At startup
+Pumperly registers one scraper per dataset listed in [`index.ts`](./index.ts) and
+upserts it like any other source. Rows are keyed by `(source, country)`, so your
+dataset only ever touches its own rows — it can't affect anyone else's data.
+
+## Add your data in 4 steps
+
+1. **Copy the template.** Start from
+   [`us-portland-ev.example.ts`](./us-portland-ev.example.ts) and save it under a
+   descriptive name, e.g. `us-portland-ev.ts`.
+
+2. **Fill in the stations.** For every station provide **accurate WGS84
+   coordinates** (`latitude` / `longitude`, the same numbers you'd read off
+   OpenStreetMap or Google Maps). Each field:
+
+   | Field | Required | Notes |
+   |-------|----------|-------|
+   | `externalId` | ✅ | Unique, stable string within your dataset (e.g. `us-pdx-tesla-sw-broadway`). |
+   | `name` | ✅ | Human-readable station name. |
+   | `brand` | ✅ | Network/operator, or `null`. |
+   | `address` | ✅ | Street address (use `""` if unknown). |
+   | `city` | ✅ | City (use `""` if unknown). |
+   | `province` | ✅ | State/region, or `null`. |
+   | `latitude` / `longitude` | ✅ | Accurate decimal degrees. **Entries left at `0,0` are dropped**, so nothing half-filled reaches the map. |
+   | `stationType` | ✅ | `"ev_charger"`, `"fuel"`, or `"both"`. |
+
+   For **fuel** stations you can also add a `prices` array (`stationExternalId`,
+   `fuelType`, `price` per litre, ISO-4217 `currency`). EV chargers omit prices.
+
+3. **Register it** in [`index.ts`](./index.ts):
+
+   ```ts
+   import { usPortlandEv } from "./us-portland-ev";
+
+   export const STATIC_DATASETS: StaticDataset[] = [usPortlandEv];
+   ```
+
+4. **Open a PR.** CI runs typecheck, lint and tests. If it's green, it ships.
+
+## Data quality rules
+
+- **Coordinates must be real and accurate** — this is data people navigate by.
+  Verify each one on a map before submitting. Don't guess.
+- **No fabricated stations.** Only add places that actually exist.
+- **Cite your sources** in the PR description (OpenStreetMap, PlugShare,
+  operator sites, etc.). Open data with a compatible licence only.
+- Keep `externalId`s stable across edits so re-imports update rather than
+  duplicate.
+
+Thanks for making Pumperly more useful where you live. 🚗⚡

--- a/src/scrapers/data/index.ts
+++ b/src/scrapers/data/index.ts
@@ -1,0 +1,15 @@
+import type { StaticDataset } from "../static";
+
+// ---------------------------------------------------------------------------
+// Registry of static / community-contributed datasets.
+// ---------------------------------------------------------------------------
+// Add your dataset here to activate it. Each entry is registered automatically
+// (in ../../instrumentation.ts) as a scraper keyed `STATIC_<SOURCE>`, so no
+// other wiring is needed. See ./README.md for the full contribution guide.
+//
+// Example:
+//   import { usPortlandEv } from "./us-portland-ev";
+//   export const STATIC_DATASETS: StaticDataset[] = [usPortlandEv];
+// ---------------------------------------------------------------------------
+
+export const STATIC_DATASETS: StaticDataset[] = [];

--- a/src/scrapers/data/us-portland-ev.example.ts
+++ b/src/scrapers/data/us-portland-ev.example.ts
@@ -1,0 +1,81 @@
+import type { StaticDataset } from "../static";
+
+// ---------------------------------------------------------------------------
+// TEMPLATE — Portland, OR EV charging contribution (GitHub issue #78)
+// ---------------------------------------------------------------------------
+// This is a starting point, NOT live data. To contribute it for real:
+//   1. Copy this file to `us-portland-ev.ts` (drop the `.example`).
+//   2. Fill in accurate WGS84 `latitude` / `longitude` for every station
+//      (look each address up on OpenStreetMap / your mapping tool of choice).
+//      Entries left at 0/0 are dropped automatically, so nothing half-filled
+//      ever reaches the map.
+//   3. Register it in `./index.ts`:
+//        import { usPortlandEv } from "./us-portland-ev";
+//        export const STATIC_DATASETS: StaticDataset[] = [usPortlandEv];
+//   4. Open a PR. See ./README.md for the full guide.
+//
+// The station list below is transcribed from issue #78 so you only need to add
+// coordinates. Add the Level-2 chargers too once you have their addresses.
+// ---------------------------------------------------------------------------
+
+export const usPortlandEv: StaticDataset = {
+  country: "US",
+  source: "community-us-portland",
+  stations: [
+    {
+      externalId: "us-pdx-tesla-sw-broadway",
+      name: "Tesla Supercharger — SW Broadway",
+      brand: "Tesla",
+      address: "805 SW Broadway",
+      city: "Portland",
+      province: "OR",
+      latitude: 0, // TODO: accurate coordinates
+      longitude: 0, // TODO: accurate coordinates
+      stationType: "ev_charger",
+    },
+    {
+      externalId: "us-pdx-evgo-nw-raleigh",
+      name: "EVgo — NW Raleigh St",
+      brand: "EVgo",
+      address: "2170 NW Raleigh St",
+      city: "Portland",
+      province: "OR",
+      latitude: 0, // TODO
+      longitude: 0, // TODO
+      stationType: "ev_charger",
+    },
+    {
+      externalId: "us-pdx-ea-se-hawthorne",
+      name: "Electrify America — SE Hawthorne Blvd",
+      brand: "Electrify America",
+      address: "3805 SE Hawthorne Blvd",
+      city: "Portland",
+      province: "OR",
+      latitude: 0, // TODO
+      longitude: 0, // TODO
+      stationType: "ev_charger",
+    },
+    {
+      externalId: "us-pdx-tesla-ne-weidler",
+      name: "Tesla Supercharger — NE Weidler St",
+      brand: "Tesla",
+      address: "3030 NE Weidler St",
+      city: "Portland",
+      province: "OR",
+      latitude: 0, // TODO
+      longitude: 0, // TODO
+      stationType: "ev_charger",
+    },
+    {
+      externalId: "us-pdx-tesla-beaverton-hillsdale",
+      name: "Tesla Supercharger — Beaverton-Hillsdale Hwy",
+      brand: "Tesla",
+      address: "4439 SW Beaverton-Hillsdale Hwy",
+      city: "Portland",
+      province: "OR",
+      latitude: 0, // TODO
+      longitude: 0, // TODO
+      stationType: "ev_charger",
+    },
+  ],
+};

--- a/src/scrapers/static.test.ts
+++ b/src/scrapers/static.test.ts
@@ -90,6 +90,18 @@ describe("StaticScraper", () => {
 
 // Guard rail for future contributions: every registered dataset must be sane.
 describe("STATIC_DATASETS registry", () => {
+  // Mirror the normalization in instrumentation.ts so a colliding contribution
+  // (sources differing only in punctuation) fails CI instead of silently
+  // overwriting another dataset's scraper at runtime.
+  it("has no normalized STATIC_<SOURCE> key collisions", () => {
+    const keys = new Set<string>();
+    for (const ds of STATIC_DATASETS) {
+      const key = `STATIC_${ds.source.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}`;
+      expect(keys.has(key), `duplicate normalized key ${key} from source ${ds.source}`).toBe(false);
+      keys.add(key);
+    }
+  });
+
   it("every dataset has unique, plausible stations", () => {
     for (const ds of STATIC_DATASETS) {
       expect(ds.country, "country must be 2-letter ISO").toMatch(/^[A-Z]{2}$/);

--- a/src/scrapers/static.test.ts
+++ b/src/scrapers/static.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+
+// StaticScraper extends BaseScraper, which imports Prisma at module load.
+// Stub those out so the unit under test loads without a real DB.
+vi.mock("@prisma/adapter-pg", () => ({ PrismaPg: vi.fn() }));
+vi.mock("../generated/prisma/client", () => ({ PrismaClient: vi.fn() }));
+
+import { StaticScraper, type StaticDataset } from "./static";
+import { STATIC_DATASETS } from "./data";
+
+function evStation(overrides: Partial<StaticDataset["stations"][number]> = {}) {
+  return {
+    externalId: "x-1",
+    name: "Test Charger",
+    brand: "Test",
+    address: "1 Test St",
+    city: "Testville",
+    province: null,
+    latitude: 45.52,
+    longitude: -122.68,
+    stationType: "ev_charger" as const,
+    ...overrides,
+  };
+}
+
+describe("StaticScraper", () => {
+  it("exposes country and source from the dataset", () => {
+    const s = new StaticScraper({ country: "US", source: "community-x", stations: [] });
+    expect(s.country).toBe("US");
+    expect(s.source).toBe("community-x");
+  });
+
+  it("returns valid stations unchanged, with no prices for EV data", async () => {
+    const s = new StaticScraper({
+      country: "US",
+      source: "community-x",
+      stations: [evStation()],
+    });
+    const { stations, prices } = await s.fetch();
+    expect(stations).toHaveLength(1);
+    expect(stations[0].externalId).toBe("x-1");
+    expect(prices).toHaveLength(0);
+  });
+
+  it("drops null-island and out-of-range coordinates", async () => {
+    const s = new StaticScraper({
+      country: "US",
+      source: "community-x",
+      stations: [
+        evStation({ externalId: "ok" }),
+        evStation({ externalId: "null-island", latitude: 0, longitude: 0 }),
+        evStation({ externalId: "bad-lat", latitude: 91 }),
+        evStation({ externalId: "bad-lon", longitude: 181 }),
+        evStation({ externalId: "nan", latitude: Number.NaN }),
+      ],
+    });
+    const { stations } = await s.fetch();
+    expect(stations.map((x) => x.externalId)).toEqual(["ok"]);
+  });
+
+  it("de-duplicates by externalId (first wins)", async () => {
+    const s = new StaticScraper({
+      country: "US",
+      source: "community-x",
+      stations: [
+        evStation({ externalId: "dup", name: "First" }),
+        evStation({ externalId: "dup", name: "Second" }),
+      ],
+    });
+    const { stations } = await s.fetch();
+    expect(stations).toHaveLength(1);
+    expect(stations[0].name).toBe("First");
+  });
+
+  it("keeps only prices that reference a surviving station", async () => {
+    const s = new StaticScraper({
+      country: "US",
+      source: "community-fuel",
+      stations: [evStation({ externalId: "keep", stationType: "fuel" })],
+      prices: [
+        { stationExternalId: "keep", fuelType: "E5", price: 1.5, currency: "USD" },
+        { stationExternalId: "orphan", fuelType: "E5", price: 1.5, currency: "USD" },
+      ],
+    });
+    const { prices } = await s.fetch();
+    expect(prices).toHaveLength(1);
+    expect(prices[0].stationExternalId).toBe("keep");
+  });
+});
+
+// Guard rail for future contributions: every registered dataset must be sane.
+describe("STATIC_DATASETS registry", () => {
+  it("every dataset has unique, plausible stations", () => {
+    for (const ds of STATIC_DATASETS) {
+      expect(ds.country, "country must be 2-letter ISO").toMatch(/^[A-Z]{2}$/);
+      expect(ds.source, "source must be non-empty").toBeTruthy();
+      const ids = new Set<string>();
+      for (const st of ds.stations) {
+        expect(st.externalId, `duplicate externalId in ${ds.source}`).not.toBe("");
+        expect(ids.has(st.externalId), `duplicate externalId ${st.externalId}`).toBe(false);
+        ids.add(st.externalId);
+        expect(st.latitude).toBeGreaterThanOrEqual(-90);
+        expect(st.latitude).toBeLessThanOrEqual(90);
+        expect(st.longitude).toBeGreaterThanOrEqual(-180);
+        expect(st.longitude).toBeLessThanOrEqual(180);
+        expect(st.latitude === 0 && st.longitude === 0, "null-island coordinates").toBe(false);
+      }
+    }
+  });
+});

--- a/src/scrapers/static.ts
+++ b/src/scrapers/static.ts
@@ -1,0 +1,83 @@
+import { BaseScraper, type RawFuelPrice, type RawStation } from "./base";
+
+// ---------------------------------------------------------------------------
+// Static / community-contributed station data
+// ---------------------------------------------------------------------------
+// Some regions have no live API Pumperly can scrape (e.g. much of the US, or a
+// single city a contributor knows well). This scraper lets anyone add stations
+// by committing a plain data file — no upstream API, no network calls.
+//
+// To contribute, see ./data/README.md: copy the example dataset, fill in
+// accurate WGS84 coordinates, add it to ./data/index.ts, and open a PR.
+//
+// The data flows through the exact same persistence path as every live scraper
+// (BaseScraper.run): rows are keyed by (source, country), so a static dataset
+// only ever touches its own rows and never clobbers another source. EV chargers
+// carry no fuel prices and are kept as-is.
+// ---------------------------------------------------------------------------
+
+export interface StaticDataset {
+  /** ISO 3166-1 alpha-2 country code these stations belong to (e.g. "US"). */
+  country: string;
+  /**
+   * Provenance label, stored on every row's `source` column. Keep it stable and
+   * unique per dataset (e.g. "community-us-portland") — re-imports replace only
+   * rows carrying this exact source, so changing it later orphans the old rows.
+   */
+  source: string;
+  /** Hand-curated stations. externalId must be unique within the dataset. */
+  stations: RawStation[];
+  /** Optional fuel prices (omit for EV-only datasets). */
+  prices?: RawFuelPrice[];
+}
+
+/**
+ * StaticScraper — serves a committed {@link StaticDataset} through the standard
+ * scrape-and-persist pipeline. Defensively drops entries with out-of-range or
+ * null-island coordinates and de-duplicates by externalId so a malformed
+ * contribution can't poison the map.
+ */
+export class StaticScraper extends BaseScraper {
+  readonly country: string;
+  readonly source: string;
+  private readonly dataset: StaticDataset;
+
+  constructor(dataset: StaticDataset) {
+    super();
+    this.country = dataset.country;
+    this.source = dataset.source;
+    this.dataset = dataset;
+  }
+
+  async fetch(): Promise<{ stations: RawStation[]; prices: RawFuelPrice[] }> {
+    const seen = new Set<string>();
+    const stations: RawStation[] = [];
+
+    for (const s of this.dataset.stations) {
+      // Reject out-of-range and null-island (0,0) coordinates.
+      if (!Number.isFinite(s.latitude) || !Number.isFinite(s.longitude)) continue;
+      if (s.latitude < -90 || s.latitude > 90) continue;
+      if (s.longitude < -180 || s.longitude > 180) continue;
+      if (s.latitude === 0 && s.longitude === 0) continue;
+      // Enforce unique externalId (first occurrence wins).
+      if (!s.externalId || seen.has(s.externalId)) continue;
+      seen.add(s.externalId);
+      stations.push(s);
+    }
+
+    const dropped = this.dataset.stations.length - stations.length;
+    if (dropped > 0) {
+      console.warn(
+        `[${this.source}] Dropped ${dropped} station(s) with invalid/duplicate coordinates`,
+      );
+    }
+
+    // Keep only prices that reference a surviving station.
+    const validIds = new Set(stations.map((s) => s.externalId));
+    const prices = (this.dataset.prices ?? []).filter((p) =>
+      validIds.has(p.stationExternalId),
+    );
+
+    return { stations, prices };
+  }
+}


### PR DESCRIPTION
## What & why

Adds a **static / community station-data contribution path** so anyone can add stations for regions Pumperly has no live API for — by committing a data file and opening a PR. No API keys, no backend access.

Motivated by #78 (a request to add Portland, OR EV charging stations). Rather than hard-code one contributor's list, this ships the reusable mechanism so contributors can submit — and maintain — their own local data.

## Changes

- **`src/scrapers/static.ts`** — `StaticScraper` + `StaticDataset`. Serves committed data through the standard `BaseScraper` persistence path (rows keyed by `(source, country)`, so a dataset only ever touches its own rows). Defensive: drops null-island / out-of-range coordinates, de-dupes by `externalId`, filters orphan prices.
- **`src/scrapers/data/index.ts`** — `STATIC_DATASETS` registry (empty; contributors append one line).
- **`src/scrapers/data/README.md`** — contribution guide (4 steps, field table, data-quality rules).
- **`src/scrapers/data/us-portland-ev.example.ts`** — ready-to-finish template pre-filled with #78's stations (coordinates left as `TODO` → auto-dropped until filled, so nothing half-done reaches the map).
- **`src/instrumentation.ts`** — auto-registers each dataset as a `STATIC_<SOURCE>` scraper.
- **`src/scrapers/static.test.ts`** — unit tests + a registry guard that fails CI on any malformed future contribution.

## Notes

- EV chargers flow through the existing `ev_charger` station type; the map + `/api/stations` render any DB row, so contributed stations appear without further wiring. (Routing/geocoding stay EU-only, same as the existing MX/AR/AU display-only sources.)
- No functional change to any existing scraper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for curated, static station datasets alongside existing data sources.
  - Expanded available station data through automatically registered dataset scrapers.
  - Added support for static EV charging station information and optional fuel prices.

- **Bug Fixes**
  - Invalid coordinates and duplicate stations are now excluded automatically.
  - Prices linked to removed stations are filtered out.

- **Documentation**
  - Added guidance for contributing and maintaining station datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->