### PR TITLE
ci: ignore TypeScript major bumps in Dependabot until the toolchain supports the native port

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,16 @@ updates:
           - '*'
     reviewers:
       - GeiserX
+    ignore:
+      # TypeScript 7 is the native (Go) compiler port. Next.js and
+      # typescript-eslint don't support it yet: `tsc --noEmit` crashes
+      # (TypeError reading 'Cjs') and `next build` fails because the native
+      # port doesn't expose the programmatic TS API those tools consume.
+      # Stay on the TypeScript 6.x line until the toolchain catches up; drop
+      # this ignore once Next.js + typescript-eslint declare TS 7 support (#82).
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: docker
     directory: /docker
     schedule:


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` for **TypeScript major-version** bumps in the npm ecosystem, so the `typescript` `7.x` major isn't re-proposed while the toolchain can't build under it. Minor/patch updates on the `6.x` line still flow normally.

## Why

Dependabot #82 tried to bump `typescript` `6.0.3 → 7.0.2`. TypeScript 7 is the new **native (Go) compiler port**, and the current stack doesn't support it yet:

- `npx tsc --noEmit` crashes: `TypeError: Cannot read properties of undefined (reading 'Cjs')` (exit 2) — the TS 7 CLI shim throws before type-checking.
- `next build` fails ("Ecmascript file had an error" / "remove the tsconfig.json…") because Next.js 16 and `typescript-eslint` 8 rely on the programmatic TS compiler API that the native port doesn't expose yet (`typescript-eslint` still declares a `<6.0.0` peer).

Nothing in this repo can patch a crash inside the compiler port, so main stays on the TS 6.x line (dev-only dependency). This ignore is scoped narrowly (only `typescript`, only `semver-major`) and is documented inline with a note to remove it once Next.js + typescript-eslint declare TS 7 support.

Closes the loop on #82 (that PR is closed).
