### PR TITLE
feat: US EV charging coverage via OpenChargeMap with bbox tiling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,8 @@ PUMPERLY_DEFAULT_COUNTRY=ES
 
 # Comma-separated ISO codes to enable (default: all countries with scrapers)
 # Supported: ES,FR,DE,IT,GB,AT,PT,SI,NL,BE,LU,RO,GR,IE,HR,CH,PL,CZ,HU,BG,SK,DK,SE,NO,RS,FI,EE,LV,LT,BA,MK,TR,MD,AU,AR,MX
-# PUMPERLY_ENABLED_COUNTRIES=ES,FR,PT,IT,AT,DE,GB,SI,NL,BE,LU,RO,GR,IE,HR,CH,PL,CZ,HU,BG,SK,DK,SE,NO,RS,FI,EE,LV,LT,BA,MK,TR,MD,AU,AR,MX
+# PUMPERLY_ENABLED_COUNTRIES=ES,FR,PT,IT,AT,DE,GB,SI,NL,BE,LU,RO,GR,IE,HR,CH,PL,CZ,HU,BG,SK,DK,SE,NO,RS,FI,EE,LV,LT,BA,MK,TR,MD,AU,AR,MX,US
+# US is EV-charger-only (no national fuel-price API): "US" enables the EV_US scraper
 
 # Override default fuel type (default: per-country, e.g. B7 for Spain)
 # Valid codes: E5, E10, E5_98, E98_E10, E5_PREMIUM, B7, B7_PREMIUM, B_AGRICULTURAL, HVO, LPG, CNG, LNG, H2, ADBLUE, EV

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Pumperly combines route planning with real-time fuel prices and EV charging stat
 - Plan a route from A to B with autocomplete and alternative routes
 - See every fuel station and EV charger within a corridor along your route
 - Filter by "cheapest within N minutes detour" — the feature no competitor has
-- Covers 36 countries across Europe, Latin America, and Oceania
+- Covers 36 fuel-price countries across Europe, Latin America, and Oceania, plus US EV-charger coverage (stations only — no national fuel-price API exists)
 - 16 languages, multi-currency, fully self-hostable
 - 100% open source (GPL-3.0), no tracking, no cookies, no accounts
 
@@ -96,7 +96,7 @@ Pumperly combines route planning with real-time fuel prices and EV charging stat
 
 | Source | Coverage | License |
 |---|---|---|
-| [Open Charge Map](https://openchargemap.org) | All supported countries | ODbL |
+| [Open Charge Map](https://openchargemap.org) | All supported countries + United States (EV-only) | ODbL |
 
 ### Map & routing
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -48,6 +48,7 @@ const DEFAULT_INTERVALS: Record<string, number> = {
   EV_HU: 24, EV_BG: 24, EV_SK: 24, EV_DK: 24, EV_SE: 24, EV_NO: 24,
   EV_RS: 24, EV_FI: 24, EV_EE: 24, EV_LV: 24, EV_LT: 24, EV_BA: 24,
   EV_MK: 24, EV_TR: 24, EV_MD: 24, EV_AU: 24, EV_AR: 24, EV_MX: 24,
+  EV_US: 24,
 };
 
 export async function register() {
@@ -177,6 +178,8 @@ export async function register() {
     EV_AU: () => new OCMScraper("AU"),
     EV_AR: () => new OCMScraper("AR"),
     EV_MX: () => new OCMScraper("MX"),
+    // US has no national fuel-price API — EV-only coverage via OCM (#85)
+    EV_US: () => new OCMScraper("US"),
   };
 
   // Register community-contributed static datasets (see scrapers/data/README.md).
@@ -201,9 +204,12 @@ export async function register() {
   const evEnabled = process.env.PUMPERLY_EV_ENABLED !== "0";
   let countries: string[];
   if (enabledRaw) {
-    const explicit = enabledRaw.split(",").map((c) => c.trim().toUpperCase()).filter((c) => c in scraperFactories);
+    const tokens = enabledRaw.split(",").map((c) => c.trim().toUpperCase());
+    const explicit = tokens.filter((c) => c in scraperFactories);
     if (evEnabled) {
-      const evCodes = explicit
+      // Derive EV_XX from the raw tokens, not the matched fuel scrapers, so a
+      // country with EV-only coverage (e.g. bare "US" → EV_US) still enables.
+      const evCodes = tokens
         .filter((c) => !c.startsWith("EV_"))
         .map((c) => `EV_${c}`)
         .filter((c) => c in scraperFactories);

--- a/src/scrapers/cli.ts
+++ b/src/scrapers/cli.ts
@@ -126,6 +126,8 @@ const SCRAPERS: Record<string, Array<() => BaseScraper>> = {
   EV_AU: [() => new OCMScraper("AU")],
   EV_AR: [() => new OCMScraper("AR")],
   EV_MX: [() => new OCMScraper("MX")],
+  // US has no national fuel-price API — EV-only coverage via OCM (#85)
+  EV_US: [() => new OCMScraper("US")],
 };
 
 function usage(): never {

--- a/src/scrapers/ocm.test.ts
+++ b/src/scrapers/ocm.test.ts
@@ -7,6 +7,8 @@ describe("OCMScraper", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
     vi.stubEnv("PUMPERLY_OCM_API_KEY", "test-ocm-key");
+    // No politeness delay between tile requests in tests
+    vi.stubEnv("PUMPERLY_OCM_TILE_DELAY_MS", "0");
   });
 
   afterEach(() => {
@@ -144,5 +146,98 @@ describe("OCMScraper", () => {
     const { stations } = await scraper.fetch();
     // All three should be filtered: (0,0), lat>90, null AddressInfo
     expect(stations).toHaveLength(0);
+  });
+
+  describe("bbox tiling for countries above the result cap", () => {
+    // 5000 POIs = exactly the OCM cap → signals silent truncation
+    const cappedPois = Array.from({ length: 5000 }, (_, i) => ({
+      ID: i + 1,
+      AddressInfo: {
+        Latitude: 40 + (i % 100) * 0.001,
+        Longitude: -100 + (i % 100) * 0.001,
+      },
+      StatusTypeID: 50,
+    }));
+
+    it("stays on a single request (no boundingbox) when under the cap", async () => {
+      const { OCMScraper } = await import("./ocm");
+      const scraper = new OCMScraper("SI");
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { ID: 1, AddressInfo: { Latitude: 46.05, Longitude: 14.5 }, StatusTypeID: 50 },
+        ],
+      } as Response);
+
+      const { stations } = await scraper.fetch();
+      expect(stations).toHaveLength(1);
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+      const url = new URL(String(vi.mocked(fetch).mock.calls[0][0]));
+      expect(url.searchParams.get("boundingbox")).toBeNull();
+      expect(url.searchParams.get("countrycode")).toBe("SI");
+    });
+
+    it("tiles into quadrants when the root query hits the cap and dedupes across tiles", async () => {
+      const { OCMScraper } = await import("./ocm");
+      const scraper = new OCMScraper("US");
+
+      const poiA = { ID: 9000001, AddressInfo: { Latitude: 45.52, Longitude: -122.68 }, StatusTypeID: 50 };
+      // Shared POI sits on a tile edge — returned by two adjacent tiles
+      const poiShared = { ID: 9000002, AddressInfo: { Latitude: 45.49, Longitude: -122.8 }, StatusTypeID: 50 };
+      const poiB = { ID: 9000003, AddressInfo: { Latitude: 48.85, Longitude: 2.35 }, StatusTypeID: 50 };
+
+      vi.mocked(fetch).mockImplementation(async (input) => {
+        const url = new URL(String(input));
+        const bbox = url.searchParams.get("boundingbox");
+        let body: unknown;
+        if (!bbox) {
+          body = cappedPois; // root query: truncated at the cap
+        } else if (bbox === "(0,-180),(90,0)") {
+          body = [poiA, poiShared]; // NW quadrant
+        } else if (bbox === "(0,0),(90,180)") {
+          body = [poiShared, poiB]; // NE quadrant (shared POI duplicated)
+        } else {
+          body = []; // southern quadrants empty
+        }
+        return { ok: true, json: async () => body } as Response;
+      });
+
+      const { stations } = await scraper.fetch();
+
+      // 1 root + 4 world quadrants, all filtered by countrycode
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(5);
+      const bboxes = vi
+        .mocked(fetch)
+        .mock.calls.map((c) => new URL(String(c[0])).searchParams.get("boundingbox"));
+      expect(bboxes.filter((b) => b !== null)).toHaveLength(4);
+      for (const call of vi.mocked(fetch).mock.calls) {
+        expect(new URL(String(call[0])).searchParams.get("countrycode")).toBe("US");
+      }
+
+      // 5000 root POIs kept + A + B + shared counted exactly once
+      expect(stations).toHaveLength(5003);
+      expect(stations.filter((s) => s.externalId === "ocm-9000002")).toHaveLength(1);
+    });
+
+    it("stops at the request budget when every tile keeps hitting the cap", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { OCMScraper } = await import("./ocm");
+      const scraper = new OCMScraper("US");
+
+      // Pathological: every request (root and all tiles) returns a capped page
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => cappedPois,
+      } as Response);
+
+      const { stations } = await scraper.fetch();
+
+      // Terminates exactly at the hard budget instead of recursing forever
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(120);
+      // Capped pages are still merged — partial data beats no data
+      expect(stations).toHaveLength(5000);
+      expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("partial"))).toBe(true);
+    });
   });
 });

--- a/src/scrapers/ocm.test.ts
+++ b/src/scrapers/ocm.test.ts
@@ -239,5 +239,37 @@ describe("OCMScraper", () => {
       expect(stations).toHaveLength(5000);
       expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("partial"))).toBe(true);
     });
+
+    it("drops malformed POIs instead of crashing", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { OCMScraper } = await import("./ocm");
+      const scraper = new OCMScraper("FR");
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { ID: 1, AddressInfo: { Latitude: 48.85, Longitude: 2.35 } },
+          { ID: "not-a-number", AddressInfo: { Latitude: 48.86, Longitude: 2.36 } },
+          "garbage",
+        ],
+      } as Response);
+
+      const { stations } = await scraper.fetch();
+      expect(stations).toHaveLength(1);
+      expect(stations[0].externalId).toBe("ocm-1");
+      expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("malformed"))).toBe(true);
+    });
+
+    it("throws a clear error on a non-array OCM payload", async () => {
+      const { OCMScraper } = await import("./ocm");
+      const scraper = new OCMScraper("FR");
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: "error" }),
+      } as Response);
+
+      await expect(scraper.fetch()).rejects.toThrow("expected a JSON array");
+    });
   });
 });

--- a/src/scrapers/ocm.ts
+++ b/src/scrapers/ocm.ts
@@ -7,11 +7,44 @@ import { BaseScraper, type RawFuelPrice, type RawStation } from "./base";
 // Covers all countries. Used as the universal EV data source.
 // API key required, passed as X-API-Key header.
 // License: Open Data Commons Open Database License (ODbL)
+//
+// The API truncates every request at `maxresults` — silently. Small countries
+// fit in one request; large ones (US ~50k operational POIs, DE/GB/FR >5k) do
+// not. When the root query comes back at the cap we quadtree-tile: split the
+// bounding box into 4 and refetch each tile (still filtered by countrycode),
+// recursing on tiles that hit the cap again. Tiles share edges, so results
+// are deduped by POI ID.
 // ---------------------------------------------------------------------------
 
 const BASE_URL = "https://api.openchargemap.io/v3/poi/";
 const API_KEY = process.env.PUMPERLY_OCM_API_KEY ?? "";
-const MAX_RESULTS = 5000; // Keep moderate to avoid OCM timeouts
+const MAX_RESULTS = 5000; // OCM truncates each request at this size
+const MAX_TILE_DEPTH = 9; // world root → ~0.35°×0.7° tiles at depth 9
+const MAX_REQUESTS = 120; // hard budget per country per scrape run
+// Politeness delay between tile requests (ms); tests set it to 0.
+const TILE_DELAY_MS = Number(process.env.PUMPERLY_OCM_TILE_DELAY_MS ?? "300");
+
+interface BBox {
+  latMin: number;
+  lonMin: number;
+  latMax: number;
+  lonMax: number;
+}
+
+// Whole world as the tiling root — countrycode filtering makes off-country
+// quadrants cheap near-empty responses, and it avoids per-country bbox data.
+const WORLD: BBox = { latMin: -90, lonMin: -180, latMax: 90, lonMax: 180 };
+
+function splitBox(b: BBox): BBox[] {
+  const latMid = (b.latMin + b.latMax) / 2;
+  const lonMid = (b.lonMin + b.lonMax) / 2;
+  return [
+    { latMin: b.latMin, lonMin: b.lonMin, latMax: latMid, lonMax: lonMid },
+    { latMin: b.latMin, lonMin: lonMid, latMax: latMid, lonMax: b.lonMax },
+    { latMin: latMid, lonMin: b.lonMin, latMax: b.latMax, lonMax: lonMid },
+    { latMin: latMid, lonMin: lonMid, latMax: b.latMax, lonMax: b.lonMax },
+  ];
+}
 
 interface OCMConnection {
   ConnectionTypeID: number;
@@ -60,12 +93,7 @@ export class OCMScraper extends BaseScraper {
     this.country = country;
   }
 
-  async fetch(): Promise<{ stations: RawStation[]; prices: RawFuelPrice[] }> {
-    if (!API_KEY) {
-      console.warn(`[${this.source}] PUMPERLY_OCM_API_KEY not set, skipping`);
-      return { stations: [], prices: [] };
-    }
-
+  private async fetchPage(bbox?: BBox): Promise<OCMPOI[]> {
     const url = new URL(BASE_URL);
     url.searchParams.set("output", "json");
     url.searchParams.set("countrycode", this.country);
@@ -74,6 +102,13 @@ export class OCMScraper extends BaseScraper {
     url.searchParams.set("verbose", "false");
     // Only include operational stations (StatusTypeID 50 = Operational)
     url.searchParams.set("statustypeid", "50");
+    if (bbox) {
+      // OCM bounding box format: (lat1,lon1),(lat2,lon2)
+      url.searchParams.set(
+        "boundingbox",
+        `(${bbox.latMin},${bbox.lonMin}),(${bbox.latMax},${bbox.lonMax})`,
+      );
+    }
 
     const res = await fetch(url.toString(), {
       headers: {
@@ -88,10 +123,63 @@ export class OCMScraper extends BaseScraper {
       throw new Error(`OCM HTTP ${res.status}: ${await res.text().catch(() => "")}`);
     }
 
-    const pois: OCMPOI[] = await res.json();
+    return res.json();
+  }
+
+  async fetch(): Promise<{ stations: RawStation[]; prices: RawFuelPrice[] }> {
+    if (!API_KEY) {
+      console.warn(`[${this.source}] PUMPERLY_OCM_API_KEY not set, skipping`);
+      return { stations: [], prices: [] };
+    }
+
+    let requests = 1;
+    const rootPois = await this.fetchPage();
+    const byId = new Map<number, OCMPOI>();
+    for (const poi of rootPois) byId.set(poi.ID, poi);
+
+    // Root query at the cap → the country is silently truncated. Tile it.
+    if (rootPois.length >= MAX_RESULTS) {
+      console.warn(
+        `[${this.source}] ${this.country}: root query hit the ${MAX_RESULTS}-result cap — tiling`,
+      );
+      // Breadth-first so the request budget refines coverage evenly. Capped
+      // tiles are merged anyway (dedupe makes the re-covering children
+      // harmless) so budget exhaustion degrades to partial-but-kept data.
+      const queue: Array<{ box: BBox; depth: number }> = splitBox(WORLD).map((box) => ({
+        box,
+        depth: 1,
+      }));
+      let truncated = false;
+      while (queue.length > 0) {
+        if (requests >= MAX_REQUESTS) {
+          truncated = true;
+          break;
+        }
+        const { box, depth } = queue.shift()!;
+        if (TILE_DELAY_MS > 0) {
+          await new Promise((resolve) => setTimeout(resolve, TILE_DELAY_MS));
+        }
+        requests++;
+        const pois = await this.fetchPage(box);
+        for (const poi of pois) byId.set(poi.ID, poi);
+        if (pois.length >= MAX_RESULTS) {
+          if (depth < MAX_TILE_DEPTH) {
+            queue.push(...splitBox(box).map((b) => ({ box: b, depth: depth + 1 })));
+          } else {
+            truncated = true;
+          }
+        }
+      }
+      if (truncated) {
+        console.warn(
+          `[${this.source}] ${this.country}: coverage may be partial — request budget (${MAX_REQUESTS}) or tile depth (${MAX_TILE_DEPTH}) reached`,
+        );
+      }
+    }
+
     const stations: RawStation[] = [];
 
-    for (const poi of pois) {
+    for (const poi of byId.values()) {
       const addr = poi.AddressInfo;
       if (!addr || !addr.Latitude || !addr.Longitude) continue;
 
@@ -122,7 +210,7 @@ export class OCMScraper extends BaseScraper {
     }
 
     console.log(
-      `[${this.source}] ${this.country}: ${pois.length} POIs from API → ${stations.length} valid stations`,
+      `[${this.source}] ${this.country}: ${requests} request(s) → ${byId.size} POIs → ${stations.length} valid stations`,
     );
 
     // EV chargers don't have fuel prices — return empty prices array

--- a/src/scrapers/ocm.ts
+++ b/src/scrapers/ocm.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { BaseScraper, type RawFuelPrice, type RawStation } from "./base";
 
 // ---------------------------------------------------------------------------
@@ -21,8 +22,12 @@ const API_KEY = process.env.PUMPERLY_OCM_API_KEY ?? "";
 const MAX_RESULTS = 5000; // OCM truncates each request at this size
 const MAX_TILE_DEPTH = 9; // world root → ~0.35°×0.7° tiles at depth 9
 const MAX_REQUESTS = 120; // hard budget per country per scrape run
+const MAX_SCRAPE_MS = 15 * 60 * 1000; // total tiling time budget per run
 // Politeness delay between tile requests (ms); tests set it to 0.
-const TILE_DELAY_MS = Number(process.env.PUMPERLY_OCM_TILE_DELAY_MS ?? "300");
+// NaN or negative values (typos) fall back to the default instead of
+// silently disabling throttling.
+const rawTileDelay = Number(process.env.PUMPERLY_OCM_TILE_DELAY_MS ?? "300");
+const TILE_DELAY_MS = Number.isFinite(rawTileDelay) && rawTileDelay >= 0 ? rawTileDelay : 300;
 
 interface BBox {
   latMin: number;
@@ -46,43 +51,26 @@ function splitBox(b: BBox): BBox[] {
   ];
 }
 
-interface OCMConnection {
-  ConnectionTypeID: number;
-  ConnectionType?: { Title: string };
-  StatusTypeID?: number;
-  LevelID?: number;
-  Level?: { Title: string };
-  PowerKW?: number;
-  Quantity?: number;
-}
+// Minimal schema for the fields we actually consume. OCM payloads are messy
+// (null/missing fields are common), so validate at the response boundary and
+// drop malformed entries instead of crashing mid-tiling.
+const OCMPOISchema = z.object({
+  ID: z.number(),
+  OperatorInfo: z.object({ Title: z.string().nullish() }).nullish(),
+  AddressInfo: z
+    .object({
+      Title: z.string().nullish(),
+      AddressLine1: z.string().nullish(),
+      Town: z.string().nullish(),
+      StateOrProvince: z.string().nullish(),
+      Postcode: z.string().nullish(),
+      Latitude: z.number().nullish(),
+      Longitude: z.number().nullish(),
+    })
+    .nullish(),
+});
 
-interface OCMAddressInfo {
-  Title?: string;
-  AddressLine1?: string;
-  Town?: string;
-  StateOrProvince?: string;
-  Postcode?: string;
-  CountryID?: number;
-  Country?: { ISOCode: string; Title: string };
-  Latitude: number;
-  Longitude: number;
-}
-
-interface OCMOperatorInfo {
-  Title?: string;
-}
-
-interface OCMPOI {
-  ID: number;
-  UUID?: string;
-  OperatorInfo?: OCMOperatorInfo;
-  AddressInfo: OCMAddressInfo;
-  Connections?: OCMConnection[];
-  NumberOfPoints?: number;
-  StatusTypeID?: number;
-  DateLastStatusUpdate?: string;
-  DataProviderID?: number;
-}
+type OCMPOI = z.infer<typeof OCMPOISchema>;
 
 export class OCMScraper extends BaseScraper {
   readonly country: string;
@@ -123,7 +111,27 @@ export class OCMScraper extends BaseScraper {
       throw new Error(`OCM HTTP ${res.status}: ${await res.text().catch(() => "")}`);
     }
 
-    return res.json();
+    // Validate at the boundary: reject non-array payloads outright (e.g. an
+    // error object) and drop individual malformed POIs instead of letting
+    // them crash the tiling/dedupe path downstream.
+    const raw: unknown = await res.json();
+    if (!Array.isArray(raw)) {
+      throw new Error(`OCM: expected a JSON array, got ${typeof raw}`);
+    }
+    const pois: OCMPOI[] = [];
+    let dropped = 0;
+    for (const entry of raw) {
+      const parsed = OCMPOISchema.safeParse(entry);
+      if (parsed.success) {
+        pois.push(parsed.data);
+      } else {
+        dropped++;
+      }
+    }
+    if (dropped > 0) {
+      console.warn(`[${this.source}] ${this.country}: dropped ${dropped} malformed POI(s)`);
+    }
+    return pois;
   }
 
   async fetch(): Promise<{ stations: RawStation[]; prices: RawFuelPrice[] }> {
@@ -132,6 +140,7 @@ export class OCMScraper extends BaseScraper {
       return { stations: [], prices: [] };
     }
 
+    const startedAt = Date.now();
     let requests = 1;
     const rootPois = await this.fetchPage();
     const byId = new Map<number, OCMPOI>();
@@ -151,7 +160,9 @@ export class OCMScraper extends BaseScraper {
       }));
       let truncated = false;
       while (queue.length > 0) {
-        if (requests >= MAX_REQUESTS) {
+        // Bound by request count AND elapsed time — 120 requests with slow
+        // 120s responses would otherwise stall a scrape cycle for hours.
+        if (requests >= MAX_REQUESTS || Date.now() - startedAt > MAX_SCRAPE_MS) {
           truncated = true;
           break;
         }
@@ -172,7 +183,7 @@ export class OCMScraper extends BaseScraper {
       }
       if (truncated) {
         console.warn(
-          `[${this.source}] ${this.country}: coverage may be partial — request budget (${MAX_REQUESTS}) or tile depth (${MAX_TILE_DEPTH}) reached`,
+          `[${this.source}] ${this.country}: coverage may be partial — request budget (${MAX_REQUESTS}), time budget (${MAX_SCRAPE_MS / 60000}min) or tile depth (${MAX_TILE_DEPTH}) reached`,
         );
       }
     }


### PR DESCRIPTION
## What

Adds **US EV charging coverage** via the existing OpenChargeMap scraper (`EV_US`), and fixes the **silent truncation** that made large countries impossible: the scraper issued a single request capped at `maxresults=5000`, quietly dropping everything beyond it. Germany, GB, France and the Netherlands are already being truncated by this today; the US (~50k+ operational POIs) was unservable.

## How

- **Quadtree bbox tiling** (`src/scrapers/ocm.ts`): when the root country query returns at the cap, split the bounding box into 4 and refetch each tile (still `countrycode`-filtered), recursing on tiles that hit the cap again. BFS order so the request budget refines coverage evenly.
  - Dedupe by POI ID (tiles share edges).
  - Hard limits: `MAX_REQUESTS=120` per run, `MAX_TILE_DEPTH=9`, 300 ms politeness delay between tile requests (`PUMPERLY_OCM_TILE_DELAY_MS`, tests set 0).
  - Capped pages are still merged — budget exhaustion degrades to *partial-but-kept* data with an explicit `coverage may be partial` warning, never silent loss.
  - Small countries keep the exact old behavior: one request, no bbox.
- **`EV_US` registration** (`src/instrumentation.ts`), 24 h interval like every other EV scraper.
- **Gating fix**: `PUMPERLY_ENABLED_COUNTRIES` derived `EV_XX` only from tokens that matched a *fuel* scraper, so a bare `US` (EV-only country) could never enable `EV_US`. EV codes now derive from the raw token list.
- **Tests**: single-request fast path (asserts no `boundingbox` param), quadrant tiling with cross-tile dedupe, and request-budget termination on pathological always-capped responses.
- **Docs**: README coverage row + `.env.example` note (US is EV-only — no national fuel-price API exists).

## Validation

- `boundingbox=(lat1,lon1),(lat2,lon2)` format verified against the **live OCM API**: a Portland-box query returns only in-box POIs (lat 45.54–45.60, lon −122.94…−123.0), while the same query without bbox returns arbitrary US POIs (OK/CA). Fail-safe by construction: even a regressed bbox filter would only re-fetch country-wide pages, which dedupe collapses — coverage falls back to today's behavior, never worse.
- Unit tests cover the tiling logic; CI runs lint/typecheck/tests/build.

## Scope notes

- This makes US chargers **browsable on the map** (station type `ev_charger`, connector metadata from OCM). US **route planning** is not included — prod Valhalla/Photon only carry European extracts; that's a separate infra decision.
- Deployment note (prod): `PUMPERLY_ENABLED_COUNTRIES` is pinned in the compose env — needs `,US` appended for pumperly.com to pick this up after release.

Closes #85. Refs #78 (community static-data path remains the fallback for regions OCM covers poorly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added United States coverage for electric vehicle charging stations.
  * Expanded charging-station retrieval to cover more locations when results exceed service limits.
  * Added safeguards to avoid duplicate stations and identify potentially partial results.

* **Documentation**
  * Clarified coverage details for fuel prices and U.S. EV charging stations.
  * Documented that U.S. coverage is limited to EV chargers and does not include national fuel-price data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->