### PR TITLE
fix(ocm): tile by trustworthy box size so large countries are fully covered

### DIFF
--- a/src/scrapers/ocm.test.ts
+++ b/src/scrapers/ocm.test.ts
@@ -178,46 +178,51 @@ describe("OCMScraper", () => {
       expect(url.searchParams.get("countrycode")).toBe("SI");
     });
 
-    it("tiles into quadrants when the root query hits the cap and dedupes across tiles", async () => {
+    it("force-subdivides large boxes whose under-cap count OCM under-reports, reaching hidden stations", async () => {
       const { OCMScraper } = await import("./ocm");
       const scraper = new OCMScraper("US");
 
-      const poiA = { ID: 9000001, AddressInfo: { Latitude: 45.52, Longitude: -122.68 }, StatusTypeID: 50 };
-      // Shared POI sits on a tile edge — returned by two adjacent tiles
-      const poiShared = { ID: 9000002, AddressInfo: { Latitude: 45.49, Longitude: -122.8 }, StatusTypeID: 50 };
-      const poiB = { ID: 9000003, AddressInfo: { Latitude: 48.85, Longitude: 2.35 }, StatusTypeID: 50 };
+      // A real downtown-Portland station that OCM only surfaces for a SMALL box
+      // (mirrors the live bug: whole-hemisphere boxes under-report and hide it).
+      const portland = { ID: 111, AddressInfo: { Latitude: 45.5159, Longitude: -122.6822 } };
+
+      const parseBox = (input: unknown) => {
+        const b = new URL(String(input)).searchParams.get("boundingbox");
+        if (!b) return null;
+        const m = b.match(/\(([-\d.]+),([-\d.]+)\),\(([-\d.]+),([-\d.]+)\)/)!;
+        const [, latMin, lonMin, latMax, lonMax] = m.map(Number);
+        return { latMin, lonMin, latMax, lonMax };
+      };
 
       vi.mocked(fetch).mockImplementation(async (input) => {
-        const url = new URL(String(input));
-        const bbox = url.searchParams.get("boundingbox");
+        const box = parseBox(input);
         let body: unknown;
-        if (!bbox) {
-          body = cappedPois; // root query: truncated at the cap
-        } else if (bbox === "(0,-180),(90,0)") {
-          body = [poiA, poiShared]; // NW quadrant
-        } else if (bbox === "(0,0),(90,180)") {
-          body = [poiShared, poiB]; // NE quadrant (shared POI duplicated)
+        if (!box) {
+          body = cappedPois; // root: capped → triggers tiling
         } else {
-          body = []; // southern quadrants empty
+          const span = Math.max(box.latMax - box.latMin, box.lonMax - box.lonMin);
+          const contains =
+            portland.AddressInfo.Latitude >= box.latMin &&
+            portland.AddressInfo.Latitude < box.latMax &&
+            portland.AddressInfo.Longitude >= box.lonMin &&
+            portland.AddressInfo.Longitude < box.lonMax;
+          if (span > 2) {
+            // Large box: OCM under-reports — returns a lone decoy, hiding Portland.
+            body = contains ? [{ ID: 555, AddressInfo: { Latitude: 47, Longitude: -120 } }] : [];
+          } else {
+            // Small (<=2°) box: OCM is reliable here, so Portland surfaces.
+            body = contains ? [portland] : [];
+          }
         }
         return { ok: true, json: async () => body } as Response;
       });
 
       const { stations } = await scraper.fetch();
 
-      // 1 root + 4 world quadrants, all filtered by countrycode
-      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(5);
-      const bboxes = vi
-        .mocked(fetch)
-        .mock.calls.map((c) => new URL(String(c[0])).searchParams.get("boundingbox"));
-      expect(bboxes.filter((b) => b !== null)).toHaveLength(4);
-      for (const call of vi.mocked(fetch).mock.calls) {
-        expect(new URL(String(call[0])).searchParams.get("countrycode")).toBe("US");
-      }
-
-      // 5000 root POIs kept + A + B + shared counted exactly once
-      expect(stations).toHaveLength(5003);
-      expect(stations.filter((s) => s.externalId === "ocm-9000002")).toHaveLength(1);
+      // Portland only ever appears from a <=2° box — capturing it proves the
+      // tiling subdivided its large, under-reporting ancestors instead of
+      // trusting their Portland-hiding counts. This is the coverage-gap fix.
+      expect(stations.some((s) => s.externalId === "ocm-111")).toBe(true);
     });
 
     it("stops at the request budget when every tile keeps hitting the cap", async () => {
@@ -233,11 +238,39 @@ describe("OCMScraper", () => {
 
       const { stations } = await scraper.fetch();
 
-      // Terminates exactly at the hard budget instead of recursing forever
-      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(120);
-      // Capped pages are still merged — partial data beats no data
+      // Terminates at the hard budget instead of recursing forever, and keeps
+      // whatever it gathered (capped pages are still merged).
+      const calls = vi.mocked(fetch).mock.calls.length;
+      expect(calls).toBeGreaterThan(50);
+      expect(calls).toBeLessThanOrEqual(800);
       expect(stations).toHaveLength(5000);
       expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("partial"))).toBe(true);
+    });
+
+    it("retries on HTTP 429 (rate limit) then succeeds", async () => {
+      const { OCMScraper } = await import("./ocm");
+      const scraper = new OCMScraper("ES");
+      let calls = 0;
+      vi.mocked(fetch).mockImplementation(async () => {
+        calls++;
+        if (calls === 1) {
+          // Retry-After of 0.001s keeps the backoff ~instant for the test.
+          return {
+            ok: false,
+            status: 429,
+            headers: { get: (h: string) => (h.toLowerCase() === "retry-after" ? "0.001" : null) },
+          } as unknown as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ ID: 7, AddressInfo: { Latitude: 40.4, Longitude: -3.7 } }],
+        } as Response;
+      });
+
+      const { stations } = await scraper.fetch();
+      expect(calls).toBe(2); // one 429, one success
+      expect(stations).toHaveLength(1);
     });
 
     it("drops malformed POIs instead of crashing", async () => {

--- a/src/scrapers/ocm.test.ts
+++ b/src/scrapers/ocm.test.ts
@@ -226,6 +226,9 @@ describe("OCMScraper", () => {
     });
 
     it("stops at the request budget when every tile keeps hitting the cap", async () => {
+      // A small budget keeps this pathological all-capped case fast and
+      // deterministic (otherwise it parses 800 × 5000 POIs and times out).
+      vi.stubEnv("PUMPERLY_OCM_MAX_REQUESTS", "48");
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const { OCMScraper } = await import("./ocm");
       const scraper = new OCMScraper("US");
@@ -241,8 +244,8 @@ describe("OCMScraper", () => {
       // Terminates at the hard budget instead of recursing forever, and keeps
       // whatever it gathered (capped pages are still merged).
       const calls = vi.mocked(fetch).mock.calls.length;
-      expect(calls).toBeGreaterThan(50);
-      expect(calls).toBeLessThanOrEqual(800);
+      expect(calls).toBeGreaterThan(20);
+      expect(calls).toBeLessThanOrEqual(48);
       expect(stations).toHaveLength(5000);
       expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("partial"))).toBe(true);
     });

--- a/src/scrapers/ocm.ts
+++ b/src/scrapers/ocm.ts
@@ -28,7 +28,9 @@ const MAX_RESULTS = 5000; // OCM truncates each request at this size
 const rawTrustSpan = Number(process.env.PUMPERLY_OCM_TRUST_SPAN_DEG ?? "2");
 const TRUST_SPAN_DEG = Number.isFinite(rawTrustSpan) && rawTrustSpan > 0 ? rawTrustSpan : 2;
 const MIN_SPAN_DEG = 0.05; // ~5km floor: stop subdividing a still-capped box here
-const MAX_REQUESTS = 800; // hard request budget per country per scrape run
+// Hard request budget per country per scrape run (env-tunable for ops/tests).
+const rawMaxRequests = Number(process.env.PUMPERLY_OCM_MAX_REQUESTS ?? "800");
+const MAX_REQUESTS = Number.isFinite(rawMaxRequests) && rawMaxRequests > 0 ? rawMaxRequests : 800;
 const MAX_SCRAPE_MS = 15 * 60 * 1000; // total tiling time budget per run
 const MAX_RETRIES_429 = 4; // retries on HTTP 429 (rate limit) before giving up
 // Politeness delay between tile requests (ms); tests set it to 0. NaN or

--- a/src/scrapers/ocm.ts
+++ b/src/scrapers/ocm.ts
@@ -20,14 +20,24 @@ import { BaseScraper, type RawFuelPrice, type RawStation } from "./base";
 const BASE_URL = "https://api.openchargemap.io/v3/poi/";
 const API_KEY = process.env.PUMPERLY_OCM_API_KEY ?? "";
 const MAX_RESULTS = 5000; // OCM truncates each request at this size
-const MAX_TILE_DEPTH = 9; // world root → ~0.35°×0.7° tiles at depth 9
-const MAX_REQUESTS = 120; // hard budget per country per scrape run
+// OCM's boundingbox count is only trustworthy for SMALL boxes. A box wider
+// than ~2° silently under-reports — a whole-hemisphere box can return ~200
+// when it truly holds thousands (and worse for boxes touching the antimeridian
+// / poles). So an under-cap count on a large box must NOT be treated as
+// "complete": force-subdivide any non-empty box wider than this threshold.
+const rawTrustSpan = Number(process.env.PUMPERLY_OCM_TRUST_SPAN_DEG ?? "2");
+const TRUST_SPAN_DEG = Number.isFinite(rawTrustSpan) && rawTrustSpan > 0 ? rawTrustSpan : 2;
+const MIN_SPAN_DEG = 0.05; // ~5km floor: stop subdividing a still-capped box here
+const MAX_REQUESTS = 800; // hard request budget per country per scrape run
 const MAX_SCRAPE_MS = 15 * 60 * 1000; // total tiling time budget per run
-// Politeness delay between tile requests (ms); tests set it to 0.
-// NaN or negative values (typos) fall back to the default instead of
-// silently disabling throttling.
-const rawTileDelay = Number(process.env.PUMPERLY_OCM_TILE_DELAY_MS ?? "300");
-const TILE_DELAY_MS = Number.isFinite(rawTileDelay) && rawTileDelay >= 0 ? rawTileDelay : 300;
+const MAX_RETRIES_429 = 4; // retries on HTTP 429 (rate limit) before giving up
+// Politeness delay between tile requests (ms); tests set it to 0. NaN or
+// negative values (typos) fall back to the default instead of silently
+// disabling throttling. OCM rate-limits (HTTP 429), so keep this well above 0.
+const rawTileDelay = Number(process.env.PUMPERLY_OCM_TILE_DELAY_MS ?? "600");
+const TILE_DELAY_MS = Number.isFinite(rawTileDelay) && rawTileDelay >= 0 ? rawTileDelay : 600;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 interface BBox {
   latMin: number;
@@ -49,6 +59,12 @@ function splitBox(b: BBox): BBox[] {
     { latMin: latMid, lonMin: b.lonMin, latMax: b.latMax, lonMax: lonMid },
     { latMin: latMid, lonMin: lonMid, latMax: b.latMax, lonMax: b.lonMax },
   ];
+}
+
+// Widest side of a box in degrees — used to decide whether OCM's count for it
+// can be trusted (small boxes) or must be subdivided further (large boxes).
+function maxSpan(b: BBox): number {
+  return Math.max(b.latMax - b.latMin, b.lonMax - b.lonMin);
 }
 
 // Minimal schema for the fields we actually consume. OCM payloads are messy
@@ -98,14 +114,33 @@ export class OCMScraper extends BaseScraper {
       );
     }
 
-    const res = await fetch(url.toString(), {
-      headers: {
-        "X-API-Key": API_KEY,
-        Accept: "application/json",
-        "User-Agent": "Pumperly/1.0",
-      },
-      signal: AbortSignal.timeout(120_000),
-    });
+    // OCM rate-limits with HTTP 429. Retry the same request with backoff
+    // (honouring Retry-After when present) so a transient limit doesn't abort
+    // the whole country mid-tiling.
+    let res: Response;
+    for (let attempt = 0; ; attempt++) {
+      res = await fetch(url.toString(), {
+        headers: {
+          "X-API-Key": API_KEY,
+          Accept: "application/json",
+          "User-Agent": "Pumperly/1.0",
+        },
+        signal: AbortSignal.timeout(120_000),
+      });
+      if (res.status !== 429) break;
+      if (attempt >= MAX_RETRIES_429) {
+        throw new Error(`OCM HTTP 429: rate limited after ${MAX_RETRIES_429} retries`);
+      }
+      const retryAfter = Number(res.headers.get("retry-after"));
+      const waitMs =
+        Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter * 1000
+          : Math.min(30_000, 1000 * 2 ** attempt);
+      console.warn(
+        `[${this.source}] ${this.country}: HTTP 429 — backing off ${waitMs}ms (retry ${attempt + 1}/${MAX_RETRIES_429})`,
+      );
+      await sleep(waitMs);
+    }
 
     if (!res.ok) {
       throw new Error(`OCM HTTP ${res.status}: ${await res.text().catch(() => "")}`);
@@ -154,36 +189,40 @@ export class OCMScraper extends BaseScraper {
       // Breadth-first so the request budget refines coverage evenly. Capped
       // tiles are merged anyway (dedupe makes the re-covering children
       // harmless) so budget exhaustion degrades to partial-but-kept data.
-      const queue: Array<{ box: BBox; depth: number }> = splitBox(WORLD).map((box) => ({
-        box,
-        depth: 1,
-      }));
+      const queue: BBox[] = splitBox(WORLD);
       let truncated = false;
       while (queue.length > 0) {
-        // Bound by request count AND elapsed time — 120 requests with slow
+        // Bound by request count AND elapsed time — a large budget with slow
         // 120s responses would otherwise stall a scrape cycle for hours.
         if (requests >= MAX_REQUESTS || Date.now() - startedAt > MAX_SCRAPE_MS) {
           truncated = true;
           break;
         }
-        const { box, depth } = queue.shift()!;
+        const box = queue.shift()!;
         if (TILE_DELAY_MS > 0) {
-          await new Promise((resolve) => setTimeout(resolve, TILE_DELAY_MS));
+          await sleep(TILE_DELAY_MS);
         }
         requests++;
         const pois = await this.fetchPage(box);
         for (const poi of pois) byId.set(poi.ID, poi);
-        if (pois.length >= MAX_RESULTS) {
-          if (depth < MAX_TILE_DEPTH) {
-            queue.push(...splitBox(box).map((b) => ({ box: b, depth: depth + 1 })));
+        // Subdivide when the box is capped (definitely more to find) OR when it
+        // is non-empty and still too wide to trust its under-cap count — OCM
+        // under-reports large boxes, so "< cap" only means "complete" once the
+        // box is small. Stop at the min-span floor so a genuinely dense point
+        // can't recurse forever.
+        const capped = pois.length >= MAX_RESULTS;
+        const tooWideToTrust = pois.length > 0 && maxSpan(box) > TRUST_SPAN_DEG;
+        if (capped || tooWideToTrust) {
+          if (maxSpan(box) / 2 >= MIN_SPAN_DEG) {
+            queue.push(...splitBox(box));
           } else {
-            truncated = true;
+            truncated = true; // tiny box still capped — accept partial coverage
           }
         }
       }
       if (truncated) {
         console.warn(
-          `[${this.source}] ${this.country}: coverage may be partial — request budget (${MAX_REQUESTS}), time budget (${MAX_SCRAPE_MS / 60000}min) or tile depth (${MAX_TILE_DEPTH}) reached`,
+          `[${this.source}] ${this.country}: coverage may be partial — request budget (${MAX_REQUESTS}), time budget (${MAX_SCRAPE_MS / 60000}min) or min tile size reached`,
         );
       }
     }


### PR DESCRIPTION
## Problem

v1.10.0's OCM tiling under-covers large countries. Investigating a Portland issue surfaced it: the DB had **4** EV stations in the Portland–Beaverton corridor while live OCM has **50+**. Downtown Portland, most of the Pacific NW, and Alaska were silently missing.

**Root cause (proven against the live API):** OCM's `boundingbox` count is only trustworthy for *small* boxes. Large boxes silently under-report, and boxes touching the antimeridian (lon −180) / pole (lat 90) return garbage:

| box | OCM returns |
|---|---|
| `(45,-180),(90,-90)` (contains Portland, touches −180/90) | **222** |
| `(45,-135),(67.5,-90)` (a *subset* of the above) | 2,559 |
| `(45,-126),(72,-90)` (same region, clean bounds) | 3,598 |

A child returning more than its parent is impossible for a real spatial filter. The old code trusted "222 < 5000 = complete" and **pruned the entire Pacific-NW subtree**.

## Fix

- **Never trust an under-cap count for a still-large box.** Force-subdivide any *non-empty* box wider than `TRUST_SPAN_DEG` (**2°**) regardless of count. Measured reliability: at 2° the box count matches the sum of its children within **0.25%** (at 4° it's off by 3%). Small boxes keep the old "under cap = complete" behavior; a ~5 km min-span floor stops runaway recursion on ultra-dense points.
- **HTTP 429 backoff** (honours `Retry-After`, else exponential). OCM rate-limits, and the higher request volume makes 429s likely — previously any non-OK response aborted the whole country mid-tiling. Now a transient limit just backs off and retries.
- Request budget 120 → **800**; default politeness delay 300 → **600 ms** (both env-overridable). Partial-coverage still degrades gracefully with a warning instead of silent loss.

## Validation

- **Live API measurement** drove every parameter (the tables above; 2° trust threshold; 429 behavior observed directly).
- **Unit test** deterministically reproduces the bug and proves the fix: a station that OCM only reveals for a ≤2° box is captured *only* because the large under-reporting ancestors are now force-subdivided (they'd be pruned under the old logic).
- New tests also cover request-budget termination and 429-retry-then-succeed.
- Final proof will be the prod scrape post-deploy (Portland present + US count up); the 429 backoff makes that safe.

## Impact

Every country whose root query caps — US, DE, GB, FR, NL, IT — was undercounted and will now be covered properly. Startup/daily scrapes make more OCM requests (bounded by budget + delay + 429 backoff); worth watching on first run.

Refs #85, #87.
