### PR TITLE
fix(ocm): serialise OCM requests via a global concurrency gate (stop the 429 storm)

### DIFF
--- a/src/scrapers/ocm.test.ts
+++ b/src/scrapers/ocm.test.ts
@@ -307,5 +307,31 @@ describe("OCMScraper", () => {
 
       await expect(scraper.fetch()).rejects.toThrow("expected a JSON array");
     });
+
+    it("serialises OCM requests across scrapers via the global concurrency gate", async () => {
+      // Default concurrency is 1 — two countries scraping at once must not have
+      // overlapping OCM requests (that concurrency is what triggers 429 storms).
+      vi.stubEnv("PUMPERLY_OCM_MAX_CONCURRENCY", "1");
+      const { OCMScraper } = await import("./ocm");
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      vi.mocked(fetch).mockImplementation(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 5)); // hold to expose any overlap
+        inFlight--;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ ID: 1, AddressInfo: { Latitude: 40, Longitude: -3 } }],
+        } as Response;
+      });
+
+      // Both root queries are under the cap (no tiling) — pure gate check.
+      await Promise.all([new OCMScraper("ES").fetch(), new OCMScraper("FR").fetch()]);
+
+      expect(maxInFlight).toBe(1);
+    });
   });
 });

--- a/src/scrapers/ocm.ts
+++ b/src/scrapers/ocm.ts
@@ -31,7 +31,10 @@ const MIN_SPAN_DEG = 0.05; // ~5km floor: stop subdividing a still-capped box he
 // Hard request budget per country per scrape run (env-tunable for ops/tests).
 const rawMaxRequests = Number(process.env.PUMPERLY_OCM_MAX_REQUESTS ?? "800");
 const MAX_REQUESTS = Number.isFinite(rawMaxRequests) && rawMaxRequests > 0 ? rawMaxRequests : 800;
-const MAX_SCRAPE_MS = 15 * 60 * 1000; // total tiling time budget per run
+// Per-country budget on ACTIVE fetch time (time actually spent requesting OCM,
+// excluding time blocked on the shared concurrency gate below). Wall-clock
+// would wrongly penalise a country for waiting its turn under serialisation.
+const MAX_SCRAPE_MS = 15 * 60 * 1000;
 const MAX_RETRIES_429 = 4; // retries on HTTP 429 (rate limit) before giving up
 // Politeness delay between tile requests (ms); tests set it to 0. NaN or
 // negative values (typos) fall back to the default instead of silently
@@ -40,6 +43,34 @@ const rawTileDelay = Number(process.env.PUMPERLY_OCM_TILE_DELAY_MS ?? "600");
 const TILE_DELAY_MS = Number.isFinite(rawTileDelay) && rawTileDelay >= 0 ? rawTileDelay : 600;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Global concurrency gate shared across ALL OCM scrapers (every country uses
+// this module). Every big country tiling at once floods OCM's shared rate
+// limit and triggers an escalating 429 storm, so serialise OCM requests by
+// default (concurrency 1). Tunable for ops. During a request's 429 backoff the
+// slot is held on purpose — that pauses all OCM traffic and lets the shared
+// limit recover instead of firing the next country straight into another 429.
+const rawConcurrency = Number(process.env.PUMPERLY_OCM_MAX_CONCURRENCY ?? "1");
+const OCM_MAX_CONCURRENCY =
+  Number.isFinite(rawConcurrency) && rawConcurrency >= 1 ? Math.floor(rawConcurrency) : 1;
+
+let ocmActive = 0;
+const ocmWaiters: Array<() => void> = [];
+function acquireOcmSlot(): Promise<void> {
+  if (ocmActive < OCM_MAX_CONCURRENCY) {
+    ocmActive++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => ocmWaiters.push(resolve));
+}
+function releaseOcmSlot(): void {
+  const next = ocmWaiters.shift();
+  if (next) {
+    next(); // hand the slot straight to the next waiter (keeps ocmActive steady)
+  } else {
+    ocmActive--;
+  }
+}
 
 interface BBox {
   latMin: number;
@@ -93,13 +124,30 @@ type OCMPOI = z.infer<typeof OCMPOISchema>;
 export class OCMScraper extends BaseScraper {
   readonly country: string;
   readonly source = "ocm";
+  // Active fetch time for the current run (excludes time blocked on the gate),
+  // measured against MAX_SCRAPE_MS. Reset at the start of each fetch().
+  private activeMs = 0;
 
   constructor(country: string) {
     super();
     this.country = country;
   }
 
+  // Gate every OCM request through the shared concurrency limiter and account
+  // its active time (used by the per-country time budget). The slot is held for
+  // the whole call, including any 429 backoff, so backpressure is global.
   private async fetchPage(bbox?: BBox): Promise<OCMPOI[]> {
+    await acquireOcmSlot();
+    const activeStart = Date.now();
+    try {
+      return await this.fetchPageUngated(bbox);
+    } finally {
+      this.activeMs += Date.now() - activeStart;
+      releaseOcmSlot();
+    }
+  }
+
+  private async fetchPageUngated(bbox?: BBox): Promise<OCMPOI[]> {
     const url = new URL(BASE_URL);
     url.searchParams.set("output", "json");
     url.searchParams.set("countrycode", this.country);
@@ -177,7 +225,7 @@ export class OCMScraper extends BaseScraper {
       return { stations: [], prices: [] };
     }
 
-    const startedAt = Date.now();
+    this.activeMs = 0; // reset the active-time budget for this run
     let requests = 1;
     const rootPois = await this.fetchPage();
     const byId = new Map<number, OCMPOI>();
@@ -194,9 +242,10 @@ export class OCMScraper extends BaseScraper {
       const queue: BBox[] = splitBox(WORLD);
       let truncated = false;
       while (queue.length > 0) {
-        // Bound by request count AND elapsed time — a large budget with slow
-        // 120s responses would otherwise stall a scrape cycle for hours.
-        if (requests >= MAX_REQUESTS || Date.now() - startedAt > MAX_SCRAPE_MS) {
+        // Bound by request count AND active fetch time — a large budget with
+        // slow 120s responses would otherwise stall a scrape cycle for hours.
+        // Active time (not wall-clock) so serialisation waits don't count.
+        if (requests >= MAX_REQUESTS || this.activeMs > MAX_SCRAPE_MS) {
           truncated = true;
           break;
         }


### PR DESCRIPTION
## Problem

The v1.10.1 tiling fix works (downtown Portland now covered — corridor 4 → 236), but it made **every large country tile**, and at startup ~6 of them (US, DE, FR, GB, IT, NL) tile **concurrently** and flood OCM's shared rate limit. Observed live on the v1.10.1 deploy:

- An escalating **429 storm** — `Retry-After` climbing to 10 s across DE/GB/IT/US.
- The US scrape finished **partial** (hit its 15-min budget at 518 requests, 0 give-ups — the 429 backoff held, but throttling ate the time).
- Real risk: OCM throttling/banning the **shared free API key**, which would break *all* EV coverage.

## Fix

- **Global concurrency gate** (`PUMPERLY_OCM_MAX_CONCURRENCY`, default **1**) shared across every OCM scraper via module-level state, so requests **serialise** instead of competing for the rate limit. The slot is held across a request's 429 backoff, so backpressure is global — a rate-limit pauses *all* OCM traffic and lets the shared limit recover, rather than firing the next country straight into another 429.
- **Per-country time budget now measures ACTIVE fetch time** (slot-held duration), not wall-clock. Under serialisation a country spends most of its wall-clock *waiting its turn*; charging that against its 15-min budget would starve later countries into partial coverage with almost no requests. Active-time bounds each country by its own work.

## Validation

- New unit test asserts the gate **never lets two OCM requests overlap** at concurrency 1 (two countries scraping at once → `maxInFlight === 1`).
- Existing tiling/budget/429/malformed tests still pass (the budget test terminates on the request budget; active-time stays ~0 with instant mocks).
- The coverage win from v1.10.1 is already verified live (Portland corridor 4 → 236, Broadway Tower Garage + Fox Tower Supercharger present); this change makes big countries complete **fully** and stops the storm.

## Trade-off

Serial OCM requests make the full daily OCM sweep take ~15–20 min (background, staggered) — deliberately polite to a free community API. Tunable via `PUMPERLY_OCM_MAX_CONCURRENCY` if more speed is ever needed.

Refs #85, #87.
