### PR TITLE
ci: build ARM64 images on native runners

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,10 +70,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=amd64
 
   build-arm64:
-    # No native ARM64 self-hosted runner exists, so build arm64 via QEMU
-    # emulation on the X64 runner. Slower than native but keeps the multi-arch
-    # manifest (:tag combining -amd64 + -arm64) working without extra hardware.
-    runs-on: ubuntu-latest
+    # Build natively: QEMU emulation can stall indefinitely during Next.js
+    # production builds, blocking the multi-architecture release manifest.
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -82,9 +81,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0


### PR DESCRIPTION
## Summary
- move the ARM64 Docker build from x64 QEMU emulation to GitHub's native `ubuntu-24.04-arm` runner
- remove the unnecessary QEMU setup that stalled both v1.10.10 release attempts

## Test plan
- [x] Validate workflow YAML syntax
- [x] Confirm the workflow diff only changes ARM64 runner execution
- [ ] Merge and verify a complete native ARM64 build plus multi-architecture manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ARM64 Docker image builds to use native ARM64 runners.
  * Removed the need for emulation during ARM64 builds.
  * AMD64 builds and multi-architecture image publishing remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->