### PR TITLE
fix(deps): bump fast-uri override to ^3.1.5 (GHSA-7p8r-x3mc-p8w7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7290,9 +7290,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "effect": "^3.21.0",
     "brace-expansion": "^5.0.8",
     "minimatch": "^10.2.4",
-    "fast-uri": "^3.1.2",
+    "fast-uri": "^3.1.5",
     "postcss": "^8.5.23",
     "sharp": "^0.35.3",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
## What

Bumps the `fast-uri` npm override from `^3.1.2` → `^3.1.5`, closing the repo's only open Dependabot alert (**#90**, high severity).

## Why

[GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — *fast-uri vulnerable to host confusion via backslash authority introducer*. Vulnerable range `>= 3.0.0, < 3.1.5`; patched in **3.1.5**.

`fast-uri` isn't a direct dependency — it comes in transitively via `@prisma/streams-local` → `ajv` (`fast-uri@^3.0.1`). It was **already pinned** by an npm override, but at `^3.1.2`, which resolved to **3.1.4** — one patch below the fix. Bumping the override is the same transitive-CVE pattern already used in this repo for `hono`, `lodash`, `minimatch`, `postcss`, etc.

Staying on the **3.x** line is deliberate: `ajv` requires `^3.0.1`, so `fast-uri@4.x` (current `latest`) would fall outside its range.

## Change scope

Deliberately minimal — 1 line in `package.json`, 3 in the lockfile:

```
-      "version": "3.1.4",
+      "version": "3.1.5",
```
plus the matching `resolved` URL and `integrity` hash. Lockfile regenerated with `npm install --package-lock-only --ignore-scripts` (no `node_modules` changes, no unrelated dependency churn).

## Validation

- `3.1.5` confirmed published on the registry, and the lockfile `integrity` matches the registry's published hash for 3.1.5 exactly.
- No other dependency versions moved (verified by diffing the lockfile against `main`).
- CI (lint, typecheck, tests, build, CodeQL) is the functional gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `fast-uri` package version override to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->