### PR TITLE
fix(map): revert maplibre-gl to 5.x — v6 module-worker breaks the map in production

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,15 @@ updates:
       - dependency-name: typescript
         update-types:
           - version-update:semver-major
+      # maplibre-gl v6 broke the map in production: its module-worker resolves a
+      # relative URL that 404s under the [locale] routes, so MapLibre never
+      # initialises (black map) while the rest of the app works. react-map-gl's
+      # peer range is loose (>=1.13.0) so npm accepts it silently, and CI has no
+      # browser test to catch it. Stay on 5.x until a v6-compatible setup is
+      # verified in a real browser.
+      - dependency-name: maplibre-gl
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: docker
     directory: /docker
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@prisma/client": "^7.9.1",
         "dotenv": "^17.4.2",
         "json5": "^2.2.3",
-        "maplibre-gl": "^6.1.0",
+        "maplibre-gl": "^5.24.0",
         "next": "^16.2.12",
         "prisma": "^7.9.1",
         "react": "^19.2.8",
@@ -1991,14 +1991,35 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
-      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^5.0.0"
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/vector-tile/node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@maplibre/geojson-vt": {
@@ -2011,12 +2032,12 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
-      "integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
@@ -9190,25 +9211,27 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.1.0.tgz",
-      "integrity": "sha512-vLRukjvbUai4SXW2/jKo8rPsw6YMXuA/b4fKFVSulZKFVRHkOvk4ZmNlDSVZpTYPV0/7/iTqq8ltYdyr764b7w==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.2.0",
-        "@mapbox/unitbezier": "^1.0.0",
-        "@mapbox/vector-tile": "^3.0.0",
-        "@maplibre/geojson-vt": "^6.1.1",
-        "@maplibre/maplibre-gl-style-spec": "^26.2.1",
-        "@maplibre/mlt": "^1.1.12",
-        "@maplibre/vt-pbf": "^4.3.2",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.2.3",
+        "earcut": "^3.0.2",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.1.0",
+        "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^5.1.2",
+        "pbf": "^4.0.1",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -9221,11 +9244,17 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
-    "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
-      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
-      "license": "BSD-2-Clause"
+    "node_modules/maplibre-gl/node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@prisma/client": "^7.9.1",
     "dotenv": "^17.4.2",
     "json5": "^2.2.3",
-    "maplibre-gl": "^6.1.0",
+    "maplibre-gl": "^5.24.0",
     "next": "^16.2.12",
     "prisma": "^7.9.1",
     "react": "^19.2.8",


### PR DESCRIPTION
## The bug

**The map has been blank/black in production since v1.10.7.** Everything else kept working — routes calculate, `/api/stations` returns data (12,728 stations) — so nothing looked broken server-side and CI stayed green (there is no browser test).

Reported symptom + the console error that cracked it:

```
Failed to load module script: The server responded with a non-JavaScript
MIME type of "text/html". Strict MIME type checking is enforced for module scripts.
```

## Root cause

v1.10.7 merged Dependabot PR #99: **`maplibre-gl` 5.24.0 → 6.0.0** (a major bump). v6 starts its worker as an **ES module**, as shipped in our bundle:

```js
new Blob([`import ${JSON.stringify(new URL(r, import.meta.url))}`])
new Worker(t, { type: "module" })
```

The worker `import`s that resolved URL. Under the `[locale]` routes it resolves **relative to the page** (`/es/…`), so the request goes to `/es/_next/static/chunks/…`, which doesn't exist. The i18n middleware answers with an **HTML document**, so the browser refuses it as a module script — the error above. The worker never starts → MapLibre never initialises → only the style background paints (**black** in dark theme, cream in light).

Verified directly against production:

| request | result |
|---|---|
| `/_next/static/chunks/2sn7rtln0tgws.js` | `200 application/javascript` ✅ |
| `/es/_next/static/chunks/2sn7rtln0tgws.js` | **`404 text/html`** ← produces the exact error |
| missing chunk at correct path | `404 text/plain` (would *not* produce it) |

Also confirmed not the cause: server health, OpenFreeMap style/TileJSON/tiles (real 244 KB–1.2 MB data), CORS (`access-control-allow-origin: *`), DNS/AdGuard, CSP, and cache headers — all fine.

## The fix

- **Pin `maplibre-gl` back to `^5.24.0`** (resolves to 5.24.0). v5 uses a **classic worker**, so it has no module-import resolution to get wrong. `react-map-gl@8.1.2` supports it — its peer range `maplibre-gl: >=1.13.0` is precisely why npm accepted v6 without a peer warning.
- **Ignore `maplibre-gl` semver-major in Dependabot**, so the bump can't silently return until a v6 setup is verified in a real browser (same pattern already used for `typescript`).

## Follow-up worth doing separately

There's no browser/smoke test, which is why a blank map shipped green through 4 releases. A minimal headless check that asserts the map canvas actually renders tiles would have caught this — proposing it as its own PR rather than widening this hotfix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map rendering stability by retaining a compatible mapping version.

* **Chores**
  * Updated maintenance settings to avoid automatic upgrades that could introduce compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->