### PR TITLE
fix(deps): bump js-yaml override to ^4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8562,9 +8562,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "postcss": "^8.5.23",
     "sharp": "^0.35.3",
     "esbuild": "^0.28.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "@babel/core": "^7.29.6",
     "jsdom": {
       "undici": "^7.28.0"


### PR DESCRIPTION
## What

Bumps the `js-yaml` npm override from `^4.2.0` → `^4.3.1`, closing the repo's only open Dependabot alert (**#91**, high severity).

## Why

[GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — *quadratic CPU consumption in `!!omap` resolution* (CVE-2026-59870). Vulnerable range `>= 4.0.0, < 4.3.1`; patched in **4.3.1**.

`js-yaml` isn't a direct dependency — it arrives transitively (dev scope) and was **already pinned** by an npm override, but at `^4.2.0`, which resolved to **4.3.0** — one patch below the fix. Same stale-override pattern as the recent `fast-uri` fix (#109), and the same transitive-CVE approach already used for `hono`, `lodash`, `minimatch`, `postcss`, etc.

Staying on the **4.x** line is deliberate: `js-yaml@5.x` (current `latest`) is a major outside the ranges the transitive consumers declare.

## Change scope

1 line in `package.json`, 3 in the lockfile (`version`/`resolved`/`integrity`), regenerated with `npm install --package-lock-only --ignore-scripts` — no `node_modules` changes, no unrelated dependency churn.

## Validation

- `4.3.1` confirmed published; the lockfile `integrity` matches the registry's published hash for 4.3.1 exactly.
- Dev-only dependency, so no runtime/user-facing surface.
- CI (lint, typecheck, tests, build, CodeQL) is the functional gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML parsing dependency to a newer compatible version.
  * Includes the latest maintenance updates and improvements from the dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->