### PR TITLE
fix(deps): add nanoid override ^3.3.17 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9407,9 +9407,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "sharp": "^0.35.3",
     "esbuild": "^0.28.1",
     "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17",
     "@babel/core": "^7.29.6",
     "jsdom": {
       "undici": "^7.28.0"


### PR DESCRIPTION
Closes Dependabot alert **#92** (high): [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — *nanoid custom generators can loop indefinitely when size is zero*. Vulnerable `< 3.3.17`, patched **3.3.17**.

`nanoid` is transitive (runtime) via **postcss** (`nanoid@^3.3.16`) and had no override, so it sat at **3.3.16**. Adds an override pinning `^3.3.17` — resolves to **3.3.18**.

Staying on **3.x** is deliberate: postcss declares `^3.3.16`, and nanoid 4.x+ is ESM-only and outside that range.

**Scope:** 1 line in `package.json`, 3 in the lockfile (version/resolved/integrity), regenerated with `npm install --package-lock-only --ignore-scripts` — no unrelated churn. Integrity matches the registry's published hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to use a newer Nano ID version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->