### PR TITLE
fix(deps): stop a stack-exhaustion DoS in deepmerge-ts via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5854,9 +5854,19 @@
       "license": "MIT"
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "esbuild": "^0.28.1",
     "js-yaml": "^4.3.1",
     "nanoid": "^3.3.17",
+    "deepmerge-ts": "^8.0.1",
     "@babel/core": "^7.29.6",
     "jsdom": {
       "undici": "^7.28.0"


### PR DESCRIPTION
Dependabot alert #93: `deepmerge-ts` below 8.0.0 blows the stack when it merges recursive object graphs (GHSA-ggr8-5vv4-36mx, high).

It is not a direct dependency. It arrives through `prisma` -> `@prisma/config`, which pins it **exactly** at `7.1.5` — so waiting for Prisma is not an option, and 7.9.1 (current latest) still pins it. A `package.json` override is the only way to move it.

**Fix:** override `deepmerge-ts` to `^8.0.1`, which resolves to 8.0.1 in the lockfile (integrity verified against the registry).

**Why this is safe to force past an exact pin:**
- `@prisma/config` uses a single named import, `const { deepmerge } = await import("deepmerge-ts")`, and v8 still exports `deepmerge`.
- v8 keeps dual CJS/ESM exports (`require` -> `dist/index.cjs`) and `engines: node >= 16`, so nothing about the module format changes for its consumer.
- `npx prisma generate` — the only thing that loads `@prisma/config` — runs in all three CI jobs, so a broken override fails this PR rather than the release build.

**Blast radius is build-time only.** The runtime image is a Next.js standalone bundle; `deepmerge-ts` and `@prisma/config` are not present in the running container at all, so production was never exposed and does not need a redeploy for this.
